### PR TITLE
Validate kenshi gender for restricted categories (closes #133)

### DIFF
--- a/app/admin/individual_category.rb
+++ b/app/admin/individual_category.rb
@@ -17,7 +17,7 @@ ActiveAdmin.register IndividualCategory, as: "IndividualCategory" do
       f.input :max_age
       f.input :gender_restriction,
         as: :select,
-        collection: ActsAsCategory::GENDER_RESTRICTIONS,
+        collection: IndividualCategory.gender_restrictions.keys,
         include_blank: "Open"
     end
     f.actions

--- a/app/admin/individual_category.rb
+++ b/app/admin/individual_category.rb
@@ -1,7 +1,27 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register IndividualCategory, as: "IndividualCategory" do
-  permit_params :name, :pool_size, :out_of_pool, :min_age, :max_age, :description_en, :description_fr, :cup_id
+  permit_params :name, :pool_size, :out_of_pool, :min_age, :max_age, :gender_restriction,
+    :description_en, :description_fr, :cup_id
+
+  form do |f|
+    f.semantic_errors
+    f.inputs do
+      f.input :cup
+      f.input :name
+      f.input :description_en
+      f.input :description_fr
+      f.input :pool_size
+      f.input :out_of_pool
+      f.input :min_age
+      f.input :max_age
+      f.input :gender_restriction,
+        as: :select,
+        collection: ActsAsCategory::GENDER_RESTRICTIONS,
+        include_blank: "Open"
+    end
+    f.actions
+  end
 
   controller do
     def scoped_collection
@@ -22,6 +42,7 @@ ActiveAdmin.register IndividualCategory, as: "IndividualCategory" do
     column :out_of_pool
     column :min_age
     column :max_age
+    column :gender_restriction
     column :kenshi_count do |c|
       c.participations.size
     end
@@ -44,6 +65,7 @@ ActiveAdmin.register IndividualCategory, as: "IndividualCategory" do
       row :description_fr
       row :pool_size
       row :out_of_pool
+      row :gender_restriction
     end
     if category.pools.present?
       panel "Pools" do

--- a/app/admin/team_category.rb
+++ b/app/admin/team_category.rb
@@ -17,7 +17,7 @@ ActiveAdmin.register TeamCategory do
       f.input :max_age
       f.input :gender_restriction,
         as: :select,
-        collection: ActsAsCategory::GENDER_RESTRICTIONS,
+        collection: TeamCategory.gender_restrictions.keys,
         include_blank: "Open"
     end
     f.actions

--- a/app/admin/team_category.rb
+++ b/app/admin/team_category.rb
@@ -1,8 +1,27 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register TeamCategory do
-  permit_params :name, :pool_size, :out_of_pool, :min_age, :max_age, :description_en, :description_fr,
-    :cup_id
+  permit_params :name, :pool_size, :out_of_pool, :min_age, :max_age, :gender_restriction,
+    :description_en, :description_fr, :cup_id
+
+  form do |f|
+    f.semantic_errors
+    f.inputs do
+      f.input :cup
+      f.input :name
+      f.input :description_en
+      f.input :description_fr
+      f.input :pool_size
+      f.input :out_of_pool
+      f.input :min_age
+      f.input :max_age
+      f.input :gender_restriction,
+        as: :select,
+        collection: ActsAsCategory::GENDER_RESTRICTIONS,
+        include_blank: "Open"
+    end
+    f.actions
+  end
 
   controller do
     def scoped_collection
@@ -33,6 +52,7 @@ ActiveAdmin.register TeamCategory do
       row :description_fr
       row :pool_size
       row :out_of_pool
+      row :gender_restriction
     end
     if category.teams.present?
       panel "Teams" do

--- a/app/models/concerns/acts_as_category.rb
+++ b/app/models/concerns/acts_as_category.rb
@@ -5,15 +5,14 @@ require "translate"
 module ActsAsCategory
   extend ActiveSupport::Concern
 
-  GENDER_RESTRICTIONS = %w[female male].freeze
-
   included do
     has_many :fights, dependent: :destroy
+
+    enum :gender_restriction, {female: "female", male: "male"}
 
     validates :name, presence: true
     validates :cup_id, presence: true
     validates :name, uniqueness: {scope: :cup_id}
-    validates :gender_restriction, inclusion: {in: GENDER_RESTRICTIONS, allow_nil: true}
 
     translate :description
 

--- a/app/models/concerns/acts_as_category.rb
+++ b/app/models/concerns/acts_as_category.rb
@@ -5,12 +5,15 @@ require "translate"
 module ActsAsCategory
   extend ActiveSupport::Concern
 
+  GENDER_RESTRICTIONS = %w[female male].freeze
+
   included do
     has_many :fights, dependent: :destroy
 
     validates :name, presence: true
     validates :cup_id, presence: true
     validates :name, uniqueness: {scope: :cup_id}
+    validates :gender_restriction, inclusion: {in: GENDER_RESTRICTIONS, allow_nil: true}
 
     translate :description
 

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -14,6 +14,7 @@ class Participation < ApplicationRecord
   validates :pool_number, numericality: {only_integer: true, greater_than: 0, allow_nil: true}
   validate :individual_or_team_category
   validate :category_age
+  validate :category_gender
 
   before_validation :assign_category
 
@@ -110,6 +111,15 @@ class Participation < ApplicationRecord
       if category.max_age && age > category.max_age
         errors.add(:category, :too_old, name: category.name)
       end
+    end
+  end
+
+  private def category_gender
+    return unless kenshi && category&.gender_restriction
+
+    expected_female = category.gender_restriction == "female"
+    if kenshi.female != expected_female
+      errors.add(:category, :wrong_gender, name: category.name)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,7 @@ en:
             category:
               too_old: 'not valid: You''re too old to participate to the %{name} category!'
               too_young: 'not valid: You''re too young to participate to the %{name} category!'
+              wrong_gender: 'not valid: this category (%{name}) is restricted to a different gender!'
         purchase:
           attributes:
             product_id:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -79,6 +79,7 @@ fr:
             category:
               too_old: Désolé, mais vous êtes trop vieux pour participer à la catégorie %{name}!
               too_young: Désolé, mais vous êtes trop jeune pour participer à la catégorie %{name}!
+              wrong_gender: Désolé, mais la catégorie %{name} est réservée à un autre genre!
         purchase:
           attributes:
             product_id:

--- a/db/migrate/20260426181608_add_gender_restriction_to_individual_categories.rb
+++ b/db/migrate/20260426181608_add_gender_restriction_to_individual_categories.rb
@@ -2,6 +2,7 @@
 
 class AddGenderRestrictionToIndividualCategories < ActiveRecord::Migration[8.1]
   def change
-    add_column :individual_categories, :gender_restriction, :string
+    create_enum :gender_restriction, %w[female male]
+    add_column :individual_categories, :gender_restriction, :enum, enum_type: :gender_restriction
   end
 end

--- a/db/migrate/20260426181608_add_gender_restriction_to_individual_categories.rb
+++ b/db/migrate/20260426181608_add_gender_restriction_to_individual_categories.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGenderRestrictionToIndividualCategories < ActiveRecord::Migration[8.1]
+  def change
+    add_column :individual_categories, :gender_restriction, :string
+  end
+end

--- a/db/migrate/20260426182102_add_gender_restriction_to_team_categories.rb
+++ b/db/migrate/20260426182102_add_gender_restriction_to_team_categories.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGenderRestrictionToTeamCategories < ActiveRecord::Migration[8.1]
+  def change
+    add_column :team_categories, :gender_restriction, :string
+  end
+end

--- a/db/migrate/20260426182102_add_gender_restriction_to_team_categories.rb
+++ b/db/migrate/20260426182102_add_gender_restriction_to_team_categories.rb
@@ -2,6 +2,6 @@
 
 class AddGenderRestrictionToTeamCategories < ActiveRecord::Migration[8.1]
   def change
-    add_column :team_categories, :gender_restriction, :string
+    add_column :team_categories, :gender_restriction, :enum, enum_type: :gender_restriction
   end
 end

--- a/db/migrate/20260426183501_set_gender_restriction_on2026_ladies_category.rb
+++ b/db/migrate/20260426183501_set_gender_restriction_on2026_ladies_category.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class SetGenderRestrictionOn2026LadiesCategory < ActiveRecord::Migration[8.1]
+  def up
+    cup_id = execute("SELECT id FROM cups WHERE year = 2026 LIMIT 1").first&.fetch("id")
+    return unless cup_id
+
+    execute(<<~SQL.squish)
+      UPDATE individual_categories
+      SET gender_restriction = 'female'
+      WHERE cup_id = #{cup_id.to_i}
+        AND name = 'Ladies'
+        AND gender_restriction IS NULL
+    SQL
+  end
+
+  def down
+    cup_id = execute("SELECT id FROM cups WHERE year = 2026 LIMIT 1").first&.fetch("id")
+    return unless cup_id
+
+    execute(<<~SQL.squish)
+      UPDATE individual_categories
+      SET gender_restriction = NULL
+      WHERE cup_id = #{cup_id.to_i}
+        AND name = 'Ladies'
+        AND gender_restriction = 'female'
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2024_01_02_133729) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_26_181608) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "heroku_ext.pg_stat_statements"
   enable_extension "pg_catalog.plpgsql"
-  enable_extension "pg_stat_statements"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
@@ -159,6 +159,7 @@ ActiveRecord::Schema[8.1].define(version: 2024_01_02_133729) do
     t.text "description_de"
     t.text "description_en"
     t.text "description_fr"
+    t.string "gender_restriction"
     t.integer "max_age"
     t.integer "min_age"
     t.string "name", limit: 255, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_26_181608) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_26_182102) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "heroku_ext.pg_stat_statements"
   enable_extension "pg_catalog.plpgsql"
@@ -265,6 +265,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_26_181608) do
     t.text "description_de"
     t.text "description_en"
     t.text "description_fr"
+    t.string "gender_restriction"
     t.integer "max_age"
     t.integer "min_age"
     t.string "name", limit: 255, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_26_182102) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_26_183501) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "heroku_ext.pg_stat_statements"
   enable_extension "pg_catalog.plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,6 +18,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_26_183501) do
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
   create_enum "document_type", ["passport", "id_card"]
+  create_enum "gender_restriction", ["female", "male"]
 
   create_table "active_admin_comments", id: :serial, force: :cascade do |t|
     t.integer "author_id"
@@ -159,7 +160,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_26_183501) do
     t.text "description_de"
     t.text "description_en"
     t.text "description_fr"
-    t.string "gender_restriction"
+    t.enum "gender_restriction", enum_type: "gender_restriction"
     t.integer "max_age"
     t.integer "min_age"
     t.string "name", limit: 255, null: false
@@ -265,7 +266,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_26_183501) do
     t.text "description_de"
     t.text "description_en"
     t.text "description_fr"
-    t.string "gender_restriction"
+    t.enum "gender_restriction", enum_type: "gender_restriction"
     t.integer "max_age"
     t.integer "min_age"
     t.string "name", limit: 255, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,8 +12,8 @@
 
 ActiveRecord::Schema[8.1].define(version: 2026_04_26_183501) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "heroku_ext.pg_stat_statements"
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "pg_stat_statements"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.

--- a/lib/tasks/temporary/cups/add_2026.rake
+++ b/lib/tasks/temporary/cups/add_2026.rake
@@ -159,6 +159,7 @@ namespace :temporary do
           out_of_pool: 2,
           min_age: 17,
           max_age: nil,
+          gender_restriction: "female",
           description_en: "For ladies who are 16 years or older.
           Participants less than 18 years old
           will be required to show a document signed by a legal representative".squish,

--- a/spec/models/individual_category_spec.rb
+++ b/spec/models/individual_category_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe IndividualCategory do
       expect(build(:individual_category, cup: cup, gender_restriction: "male")).to be_valid
     end
 
-    it "rejects an unknown gender_restriction value" do
-      category = build(:individual_category, cup: cup, gender_restriction: "other")
-      expect(category).not_to be_valid
-      expect(category.errors[:gender_restriction]).to be_present
+    it "raises on an unknown gender_restriction value" do
+      expect {
+        build(:individual_category, cup: cup, gender_restriction: "other")
+      }.to raise_error(ArgumentError, /not a valid gender_restriction/)
     end
   end
 

--- a/spec/models/individual_category_spec.rb
+++ b/spec/models/individual_category_spec.rb
@@ -31,6 +31,28 @@ RSpec.describe IndividualCategory do
     end
   end
 
+  describe "Validations" do
+    let(:cup) { create(:cup) }
+
+    it "accepts nil gender_restriction (open category)" do
+      expect(build(:individual_category, cup: cup, gender_restriction: nil)).to be_valid
+    end
+
+    it "accepts \"female\" gender_restriction" do
+      expect(build(:individual_category, cup: cup, gender_restriction: "female")).to be_valid
+    end
+
+    it "accepts \"male\" gender_restriction" do
+      expect(build(:individual_category, cup: cup, gender_restriction: "male")).to be_valid
+    end
+
+    it "rejects an unknown gender_restriction value" do
+      category = build(:individual_category, cup: cup, gender_restriction: "other")
+      expect(category).not_to be_valid
+      expect(category.errors[:gender_restriction]).to be_present
+    end
+  end
+
   describe "A individual_category “open”" do
     let!(:individual_category) {
       create(:individual_category, name: "open", pool_size: 3, out_of_pool: 2,

--- a/spec/models/participation_spec.rb
+++ b/spec/models/participation_spec.rb
@@ -127,6 +127,67 @@ RSpec.describe Participation do
         }
       end
     end
+
+    describe "#category_gender" do
+      let(:cup) { create(:cup, start_on: 2.months.from_now) }
+
+      context "when category has no gender_restriction" do
+        let(:individual_category) { create(:individual_category, cup: cup, gender_restriction: nil) }
+
+        it "is valid for a female kenshi" do
+          kenshi = create(:kenshi, cup: cup, female: true)
+          expect(build(:participation, kenshi: kenshi, category: individual_category)).to be_valid
+        end
+
+        it "is valid for a male kenshi" do
+          kenshi = create(:kenshi, cup: cup, female: false)
+          expect(build(:participation, kenshi: kenshi, category: individual_category)).to be_valid
+        end
+      end
+
+      context "when category is gender_restriction: \"female\"" do
+        let(:individual_category) { create(:individual_category, cup: cup, gender_restriction: "female") }
+
+        it "is valid for a female kenshi" do
+          kenshi = create(:kenshi, cup: cup, female: true)
+          expect(build(:participation, kenshi: kenshi, category: individual_category)).to be_valid
+        end
+
+        it "is invalid for a male kenshi" do
+          kenshi = create(:kenshi, cup: cup, female: false)
+          participation = build(:participation, kenshi: kenshi, category: individual_category)
+          expect(participation).not_to be_valid
+          expect(participation.errors[:category]).to be_present
+        end
+      end
+
+      context "when category is gender_restriction: \"male\"" do
+        let(:individual_category) { create(:individual_category, cup: cup, gender_restriction: "male") }
+
+        it "is valid for a male kenshi" do
+          kenshi = create(:kenshi, cup: cup, female: false)
+          expect(build(:participation, kenshi: kenshi, category: individual_category)).to be_valid
+        end
+
+        it "is invalid for a female kenshi" do
+          kenshi = create(:kenshi, cup: cup, female: true)
+          participation = build(:participation, kenshi: kenshi, category: individual_category)
+          expect(participation).not_to be_valid
+          expect(participation.errors[:category]).to be_present
+        end
+      end
+
+      context "when category is a TeamCategory with gender_restriction: \"female\"" do
+        let(:team_category) { create(:team_category, cup: cup, gender_restriction: "female") }
+
+        it "is invalid for a male kenshi" do
+          kenshi = create(:kenshi, cup: cup, female: false)
+          participation = build(:participation, kenshi: kenshi, category: team_category)
+          expect(participation).not_to be_valid
+          expect(participation.errors[:category]).to be_present
+        end
+      end
+    end
   end
 
   describe "#product" do

--- a/spec/models/team_category_spec.rb
+++ b/spec/models/team_category_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe TeamCategory do
       expect(build(:team_category, cup: cup, gender_restriction: "male")).to be_valid
     end
 
-    it "rejects an unknown gender_restriction value" do
-      category = build(:team_category, cup: cup, gender_restriction: "other")
-      expect(category).not_to be_valid
-      expect(category.errors[:gender_restriction]).to be_present
+    it "raises on an unknown gender_restriction value" do
+      expect {
+        build(:team_category, cup: cup, gender_restriction: "other")
+      }.to raise_error(ArgumentError, /not a valid gender_restriction/)
     end
   end
 

--- a/spec/models/team_category_spec.rb
+++ b/spec/models/team_category_spec.rb
@@ -31,6 +31,28 @@ RSpec.describe TeamCategory do
     end
   end
 
+  describe "Validations" do
+    let(:cup) { create(:cup) }
+
+    it "accepts nil gender_restriction (open category)" do
+      expect(build(:team_category, cup: cup, gender_restriction: nil)).to be_valid
+    end
+
+    it "accepts \"female\" gender_restriction" do
+      expect(build(:team_category, cup: cup, gender_restriction: "female")).to be_valid
+    end
+
+    it "accepts \"male\" gender_restriction" do
+      expect(build(:team_category, cup: cup, gender_restriction: "male")).to be_valid
+    end
+
+    it "rejects an unknown gender_restriction value" do
+      category = build(:team_category, cup: cup, gender_restriction: "other")
+      expect(category).not_to be_valid
+      expect(category.errors[:gender_restriction]).to be_present
+    end
+  end
+
   describe "A team_category team" do
     let!(:team_category) {
       create(:team_category, name: "team", pool_size: 3, out_of_pool: 2,


### PR DESCRIPTION
## Summary

- Adds a nullable `gender_restriction` column to both `individual_categories` and `team_categories`, backed by a Postgres `enum` type (`"female"` / `"male"`) that rejects unknown values at the DB layer. Rails models use the `enum` macro on the shared `ActsAsCategory` concern, exposing `.female` / `.male` scopes and `female?` / `male?` predicates.
- Adds a `Participation#category_gender` validation that mirrors the existing `category_age` pattern: when a kenshi is registered to a category whose `gender_restriction` does not match `kenshi.female`, the participation fails to save with a localized `:wrong_gender` error (en + fr).
- Exposes `gender_restriction` in ActiveAdmin for both category types (permit_params, form select sourced from `Model.gender_restrictions.keys`, show row, plus index column for individuals).
- Backfills `gender_restriction = "female"` on the **2026** Ladies `IndividualCategory` only (data migration scoped strictly to year 2026). Past cups (2014–2025) keep `gender_restriction = nil` and behave exactly as before.
- Updates `lib/tasks/temporary/cups/add_2026.rake` so re-running it produces the same state.
- One unrelated fix-up: drops `heroku_ext.` schema qualification from the `pg_stat_statements` extension in `db/schema.rb` (the dev DB has the extension installed under that schema; the test DB does not, so loading schema.rb was failing in the test env). Commit body explains how to fix the dev DB so the prefix stops coming back.

Spec: `docs/superpowers/specs/2026-04-26-ladies-validation-design.md` (kept local on this branch by request).

## Test Plan

- [x] `bundle exec rspec` — 326 examples, 0 failures
- [ ] In ActiveAdmin → Individual Categories, edit the 2026 "Ladies" row: verify the gender_restriction select renders with `Open / female / male` and that "female" is preselected
- [ ] In the public registration flow, try registering a male kenshi for the 2026 Ladies category — expect the form to re-render with the `wrong_gender` error message
- [ ] Register a female kenshi for the 2026 Ladies category — expect success
- [ ] Register a male kenshi for any other 2026 category — expect success (no regression)
- [ ] Optional: in admin, set a TeamCategory to `gender_restriction: "male"` and confirm a female kenshi participation is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)