### PR TITLE
Improve pool generation and cross-pool bracket seeding

### DIFF
--- a/app/admin/individual_category.rb
+++ b/app/admin/individual_category.rb
@@ -48,7 +48,8 @@ ActiveAdmin.register IndividualCategory, as: "IndividualCategory" do
     end
     actions do |category|
       [
-        link_to("Smart reset", reset_smart_pools_admin_individual_category_path(category), confirm: "Are you sure?"),
+        link_to("Smart reset", reset_smart_pools_admin_individual_category_path(category),
+          data: {confirm: "Regenerate all pools for this category? Manual pool assignments will be lost."}),
         link_to("PDF", pdf_admin_individual_category_path(category)),
         link_to("PDF recap", pdf_recap_admin_individual_category_path(category)),
         link_to("Match sheet", sheet_admin_individual_category_path(category)),
@@ -127,7 +128,7 @@ ActiveAdmin.register IndividualCategory, as: "IndividualCategory" do
               link_to("Destroy",
                 admin_participation_path(participation),
                 method: :delete,
-                confirm: "Are you extra sure?")
+                data: {confirm: "Are you extra sure?"})
             ].join(" ").html_safe
           end
         end
@@ -163,7 +164,7 @@ ActiveAdmin.register IndividualCategory, as: "IndividualCategory" do
   end
   action_item :smart_pool_reset, only: :show do
     link_to "Smart pool reset", reset_smart_pools_admin_individual_category_path(individual_category),
-      confirm: "Are you sure?"
+      data: {confirm: "Regenerate all pools for this category? Manual pool assignments will be lost."}
   end
 
   member_action :pdf do

--- a/app/models/individual_category_bracket_builder.rb
+++ b/app/models/individual_category_bracket_builder.rb
@@ -108,19 +108,20 @@ class IndividualCategoryBracketBuilder
     build_half_units(top) + build_half_units(bottom)
   end
 
-  # Split entries into a top and bottom half. For the i-th pool (0-based, sorted
-  # by number) and a qualifier of rank r, the entry goes to the top half when
-  # (i + r) is even, otherwise the bottom half. rank-1 and rank-2 differ by one
-  # in parity, so they always land in opposite halves; the per-pool starting
-  # side alternates, mixing winners and runners-up into both halves.
+  # Split entries into a top and bottom half. The pools are cut into a low block
+  # (the first half of pool numbers) and a high block. A low-block pool sends its
+  # rank-1 to the top half and rank-2 to the bottom; a high-block pool does the
+  # reverse (odd ranks follow rank-1, even ranks follow rank-2). This keeps each
+  # pool's rank-1 and rank-2 in opposite halves, and — because the low/high cut
+  # spans the whole pool-number range — lets evenly-spaced byes (see select_byes)
+  # fall one per half.
   private def assign_halves(entries)
+    low_block = pool_numbers.first((pool_numbers.size / 2.0).ceil)
     top = []
     bottom = []
-    sorted_pools = entries.group_by(&:pool_number).sort_by { |pool_number, _| pool_number }
-    sorted_pools.each_with_index do |(_pool_number, slots), pool_index|
-      slots.sort_by(&:pool_rank).each do |slot|
-        ((pool_index + slot.pool_rank).even? ? top : bottom) << slot
-      end
+    entries.each do |slot|
+      in_low_block = low_block.include?(slot.pool_number)
+      ((slot.pool_rank.odd? == in_low_block) ? top : bottom) << slot
     end
     [sort_by_strength(top), sort_by_strength(bottom)]
   end
@@ -139,22 +140,18 @@ class IndividualCategoryBracketBuilder
     units.sort_by { |pair| [pair.first.pool_number, pair.first.pool_rank] }
   end
 
-  # Byes go to the strongest entries, but each pool must keep at most
-  # fighters_per_pool fighters so the rest can be matched cross-pool, so an
-  # over-represented pool is forced to give up its strongest entries as byes
-  # first. Never force a bye when there are none to give (byes_count <= 0) — that
-  # would drop a fighter; the matcher handles same-pool pairs instead.
+  # Byes go to evenly-spaced pool winners (rank-1s) within the half, so the bye
+  # advantage is distributed across the pool-number range rather than always
+  # landing on the lowest-numbered pools. When a half has more byes than winners
+  # (a small field in a large bracket), the spread spills over the half's entries
+  # in rank-major order, so a pool may then receive more than one bye. Returns []
+  # when there are no byes — never forces one, which would drop a fighter.
   private def select_byes(slots, byes_count)
     return [] if byes_count <= 0
 
-    fighters_per_pool = (slots.size - byes_count) / 2
-    byes = slots.group_by(&:pool_number).flat_map do |_pool_number, pool_slots|
-      forced = pool_slots.size - fighters_per_pool
-      forced.positive? ? sort_by_strength(pool_slots).first(forced) : []
-    end
-    return sort_by_strength(slots).first(byes_count) if byes.size > byes_count
-
-    byes + sort_by_strength(slots - byes).first(byes_count - byes.size)
+    winners = slots.select { |slot| slot.pool_rank == 1 }.sort_by(&:pool_number)
+    source = (byes_count <= winners.size) ? winners : sort_by_strength(slots)
+    Array.new(byes_count) { |j| source[j * source.size / byes_count] }
   end
 
   # Match the (even-sized, strength-sorted) `rest` into cross-pool fights. The

--- a/app/models/individual_category_bracket_builder.rb
+++ b/app/models/individual_category_bracket_builder.rb
@@ -98,13 +98,107 @@ class IndividualCategoryBracketBuilder
   end
 
   private def first_round_pairs
-    placement = canonical_seed_placement(bracket_size)
-    bracket = placement.map { |seed| seeded_slot(seed) }
-    bracket.each_slice(2).to_a
+    entries = slot_specs
+    return [] if entries.empty?
+    return [[entries.first, nil]] if entries.size == 1
+
+    top, bottom = assign_halves(entries)
+    return [[top.first, bottom.first]] if bracket_size == 2
+
+    build_half_units(top) + build_half_units(bottom)
   end
 
-  private def seeded_slot(seed)
-    slot_specs[seed - 1]
+  # Split entries into a top and bottom half. For the i-th pool (0-based, sorted
+  # by number) and a qualifier of rank r, the entry goes to the top half when
+  # (i + r) is even, otherwise the bottom half. rank-1 and rank-2 differ by one
+  # in parity, so they always land in opposite halves; the per-pool starting
+  # side alternates, mixing winners and runners-up into both halves.
+  private def assign_halves(entries)
+    top = []
+    bottom = []
+    sorted_pools = entries.group_by(&:pool_number).sort_by { |pool_number, _| pool_number }
+    sorted_pools.each_with_index do |(_pool_number, slots), pool_index|
+      slots.sort_by(&:pool_rank).each do |slot|
+        ((pool_index + slot.pool_rank).even? ? top : bottom) << slot
+      end
+    end
+    [sort_by_strength(top), sort_by_strength(bottom)]
+  end
+
+  # Build the round-1 units (pairs; [slot, nil] for byes) for one half, spread
+  # across that half's B/4 positions via canonical placement. half_size is an
+  # even power of two (the B == 2 case returns earlier), so the post-bye `rest`
+  # cross_pool_match receives is always even-sized. Slots are unique by
+  # (pool_number, pool_rank), so `half_slots - byes` removes exactly the byes.
+  private def build_half_units(half_slots)
+    half_size = bracket_size / 2
+    byes = select_byes(half_slots, half_size - half_slots.size)
+    fights = cross_pool_match(sort_by_strength(half_slots - byes))
+    units = byes.map { |slot| [slot, nil] } + fights
+    ordered = units.sort_by { |pair| pair.compact.map { |slot| strength_key(slot) }.min }
+    canonical_seed_placement(half_size / 2).map { |seed| ordered[seed - 1] }
+  end
+
+  # Byes go to the strongest entries, but each pool must keep at most
+  # fighters_per_pool fighters so the rest can be matched cross-pool, so an
+  # over-represented pool is forced to give up its strongest entries as byes
+  # first. Never force a bye when there are none to give (byes_count <= 0) — that
+  # would drop a fighter; the matcher handles same-pool pairs instead.
+  private def select_byes(slots, byes_count)
+    return [] if byes_count <= 0
+
+    fighters_per_pool = (slots.size - byes_count) / 2
+    byes = slots.group_by(&:pool_number).flat_map do |_pool_number, pool_slots|
+      forced = pool_slots.size - fighters_per_pool
+      forced.positive? ? sort_by_strength(pool_slots).first(forced) : []
+    end
+    return sort_by_strength(slots).first(byes_count) if byes.size > byes_count
+
+    byes + sort_by_strength(slots - byes).first(byes_count - byes.size)
+  end
+
+  # Match the (even-sized, strength-sorted) `rest` into cross-pool fights. The
+  # greedy pass gives the most legible draw (a winner vs another pool's
+  # runner-up) but is a heuristic that can still leave a same-pool pair even when
+  # a cross-pool matching exists; grouped_cross_pool is the guaranteed fallback.
+  private def cross_pool_match(rest)
+    fights = greedy_cross_pool(rest)
+    same_pool?(fights) ? grouped_cross_pool(rest) : fights
+  end
+
+  # Pair each stronger entry with the next weaker entry from a different pool.
+  # `|| 0` only fires when no different-pool entry remains (a single pool filling
+  # the half, i.e. P == 1, where a same-pool meeting is unavoidable).
+  private def greedy_cross_pool(rest)
+    count = rest.size / 2
+    weaker = rest.last(count)
+    rest.first(count).map do |slot_1|
+      index = weaker.index { |slot| slot.pool_number != slot_1.pool_number } || 0
+      [slot_1, weaker.delete_at(index)]
+    end
+  end
+
+  # Guaranteed cross-pool matching: group by pool (largest first), pair i with
+  # i + half. Same-pool-free because select_byes caps every pool at <= rest/2.
+  private def grouped_cross_pool(rest)
+    grouped = rest.sort_by { |slot|
+      [-rest.count { |other| other.pool_number == slot.pool_number }, slot.pool_number, slot.pool_rank]
+    }
+    half = rest.size / 2
+    (0...half).map { |i| [grouped[i], grouped[i + half]] }
+  end
+
+  private def same_pool?(fights)
+    fights.any? { |slot_1, slot_2| slot_1 && slot_2 && slot_1.pool_number == slot_2.pool_number }
+  end
+
+  private def sort_by_strength(slots)
+    slots.sort_by { |slot| strength_key(slot) }
+  end
+
+  # Rank-major: lower rank, then lower pool number, is stronger.
+  private def strength_key(slot)
+    [slot.pool_rank, slot.pool_number]
   end
 
   private def bracket_size

--- a/app/models/individual_category_bracket_builder.rb
+++ b/app/models/individual_category_bracket_builder.rb
@@ -125,18 +125,18 @@ class IndividualCategoryBracketBuilder
     [sort_by_strength(top), sort_by_strength(bottom)]
   end
 
-  # Build the round-1 units (pairs; [slot, nil] for byes) for one half, spread
-  # across that half's B/4 positions via canonical placement. half_size is an
-  # even power of two (the B == 2 case returns earlier), so the post-bye `rest`
-  # cross_pool_match receives is always even-sized. Slots are unique by
-  # (pool_number, pool_rank), so `half_slots - byes` removes exactly the byes.
+  # Build the round-1 units (pairs; [slot, nil] for byes) for one half, ordered
+  # by leading fighter so the round-1 column reads in pool-number order within
+  # the half. half_size is an even power of two (the B == 2 case returns
+  # earlier), so the post-bye `rest` cross_pool_match receives is always
+  # even-sized. Slots are unique by (pool_number, pool_rank), so
+  # `half_slots - byes` removes exactly the byes.
   private def build_half_units(half_slots)
     half_size = bracket_size / 2
     byes = select_byes(half_slots, half_size - half_slots.size)
     fights = cross_pool_match(sort_by_strength(half_slots - byes))
     units = byes.map { |slot| [slot, nil] } + fights
-    ordered = units.sort_by { |pair| pair.compact.map { |slot| strength_key(slot) }.min }
-    canonical_seed_placement(half_size / 2).map { |seed| ordered[seed - 1] }
+    units.sort_by { |pair| [pair.first.pool_number, pair.first.pool_rank] }
   end
 
   # Byes go to the strongest entries, but each pool must keep at most
@@ -205,17 +205,6 @@ class IndividualCategoryBracketBuilder
     return 0 if slot_specs.empty?
 
     2**Math.log2(slot_specs.size).ceil
-  end
-
-  private def canonical_seed_placement(size)
-    return [] if size < 1
-
-    placement = [1]
-    while placement.size < size
-      total = placement.size * 2
-      placement = placement.flat_map { |seed| [seed, total + 1 - seed] }
-    end
-    placement
   end
 
   private def slot_specs

--- a/app/models/smart_pooler.rb
+++ b/app/models/smart_pooler.rb
@@ -15,8 +15,9 @@
 #
 # Pools number ceil(N / pool_size), so each holds either pool_size or
 # pool_size - 1 participants with the fewest short pools possible. The short
-# pools take the lowest pool numbers, which the bracket builder seeds at the top
-# of the quarter/semi tree.
+# pools are spread evenly across the pool numbers (#1, then the head of each
+# half/quarter) so the byes and easier pools the bracket builder derives from
+# them are distributed across the bracket instead of clustered at the top.
 class SmartPooler
   attr_reader :category, :participants, :poules, :pool_size
 
@@ -46,10 +47,19 @@ class SmartPooler
 
   private def build_empty_pools
     base, full_pools = participants.size.divmod(pool_count)
-    short_pools = pool_count - full_pools
+    short = short_pool_indices(pool_count - full_pools, pool_count)
     @poules = Array.new(pool_count) { Pool.new }
-    # Short pools first so they take the lowest pool numbers (top of the bracket).
-    @target_sizes = Array.new(pool_count) { |i| (i < short_pools) ? base : base + 1 }
+    @target_sizes = Array.new(pool_count) { |i| short.include?(i) ? base : base + 1 }
+  end
+
+  # Zero-based indices of the short pools, spread evenly across the pool numbers
+  # so they head the bracket's halves/quarters instead of clustering at the top.
+  # With P pools and k short pools the i-th sits at round(i * P / k): e.g. 12
+  # pools with 2 short -> indices 0 and 6 -> pool numbers 1 and 7.
+  private def short_pool_indices(count, total)
+    return [] if count.zero?
+
+    Array.new(count) { |i| (i * total.to_f / count).round }
   end
 
   # Strongest first so LPT balancing spreads the top fighters across pools;

--- a/app/models/smart_pooler.rb
+++ b/app/models/smart_pooler.rb
@@ -1,47 +1,91 @@
 # frozen_string_literal: true
 
+# Distributes a category's participants into pools, balancing three goals:
+#
+#   1. Randomness    - a different valid layout on every reset.
+#   2. Club spread   - members of the same club land in different pools whenever
+#                      possible (and are spread as evenly as possible when a club
+#                      has more members than there are pools).
+#   3. Grade balance - strength is spread evenly so no pool is all-strong or
+#                      all-weak.
+#
+# Strategy: order participants strongest-first (randomised within equal grades),
+# then drop each into the weakest pool that still has room and does not already
+# hold their club (LPT balancing + club-aware placement).
+#
+# Pools number ceil(N / pool_size), so each holds either pool_size or
+# pool_size - 1 participants with the fewest short pools possible. The short
+# pools take the lowest pool numbers, which the bracket builder seeds at the top
+# of the quarter/semi tree.
 class SmartPooler
   attr_reader :category, :participants, :poules, :pool_size
 
-  def initialize(category)
+  def initialize(category, random: Random.new)
     @category = category
+    @random = random
     @pool_size = category.pool_size
-    @participants = category.participations.to_a
+    # Stable id order keeps results reproducible for a given random seed.
+    @participants = category.participations.includes(kenshi: :club).order(:id).to_a
     @poules = []
   end
 
   def set_pools
-    poule = Pool.new
-    while participants.size > 0
-      participants.shuffle!
-      selected_participants = participants
-      if poule.contains_high_rank?
-        selected_participants = selected_participants.select { |p| p.kenshi.grade.to_i < 3 }
+    return clear_pools! if pool_size.to_i <= 1
+    return if participants.empty?
+
+    build_empty_pools
+    ordered_participants.each { |participation| pick_pool(participation).participations << participation }
+    persist!
+  end
+
+  private attr_reader :random, :target_sizes
+
+  private def pool_count
+    [(participants.size.to_f / pool_size).ceil, 1].max
+  end
+
+  private def build_empty_pools
+    base, full_pools = participants.size.divmod(pool_count)
+    short_pools = pool_count - full_pools
+    @poules = Array.new(pool_count) { Pool.new }
+    # Short pools first so they take the lowest pool numbers (top of the bracket).
+    @target_sizes = Array.new(pool_count) { |i| (i < short_pools) ? base : base + 1 }
+  end
+
+  # Strongest first so LPT balancing spreads the top fighters across pools;
+  # the random key shuffles fighters of equal grade.
+  private def ordered_participants
+    participants.sort_by { |p| [-p.kenshi.grade.to_i, random.rand] }
+  end
+
+  private def pick_pool(participation)
+    open = open_pools
+    club = participation.kenshi.club
+    candidates = club.present? ? open.reject { |pool| pool.contains_club?(club) } : open
+    candidates = open if candidates.empty? # club collision unavoidable
+    candidates.min_by { |pool| [pool.total_dan, pool.participations.size, random.rand] }
+  end
+
+  private def open_pools
+    poules.select.with_index { |pool, i| pool.participations.size < target_sizes[i] }
+  end
+
+  private def persist!
+    Participation.transaction do
+      poules.each_with_index do |pool, i|
+        pool.participations.each_with_index do |participation, j|
+          participation.update!(pool_number: i + 1, pool_position: j + 1)
+        end
       end
-      already_selected_clubs = poule.participations.map { |p| p.kenshi.club }
-      selected_participants = selected_participants.select { |p| already_selected_clubs.exclude?(p.kenshi.club) }
-      p = if selected_participants.empty?
-        participants.first
-      else
-        selected_participants.first
-      end
-      poule.participations << participants.delete(p)
-      if poule.participations.size == pool_size || participants.empty?
-        poules << poule
-        poule = Pool.new
-      end
-      set_participations
     end
   end
 
-  protected def set_participations
+  private def clear_pools!
     Participation.transaction do
-      poules.each_with_index do |poule, i|
-        poule.participations.each_with_index do |participation, j|
-          participation.update(pool_number: i + 1, pool_position: j + 1)
-        end
-      rescue StandardError? => e
-        Rails.logger.debug e
+      participants.each do |participation|
+        next if participation.pool_number.nil? && participation.pool_position.nil?
+
+        participation.update!(pool_number: nil, pool_position: nil)
       end
     end
   end

--- a/spec/models/individual_category_bracket_builder_spec.rb
+++ b/spec/models/individual_category_bracket_builder_spec.rb
@@ -179,8 +179,8 @@ RSpec.describe IndividualCategoryBracketBuilder do
         round_one = fights.select { |f| f.round == 1 }.sort_by(&:position)
 
         expect(round_one.map { |f| [f.fighter_1, f.fighter_2] }).to eq([
-          [p2_1.kenshi, nil],
           [p1_2.kenshi, p3_2.kenshi],
+          [p2_1.kenshi, nil],
           [p1_1.kenshi, nil],
           [p3_1.kenshi, p2_2.kenshi]
         ])

--- a/spec/models/individual_category_bracket_builder_spec.rb
+++ b/spec/models/individual_category_bracket_builder_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe IndividualCategoryBracketBuilder do
         round_one = fights.select { |f| f.round == 1 }.sort_by(&:position)
 
         expect(round_one.map { |f| [f.fighter_1, f.fighter_2] }).to eq([
-          [p2_1.kenshi, p1_2.kenshi],
-          [p4_1.kenshi, p3_2.kenshi],
-          [p1_1.kenshi, p2_2.kenshi],
-          [p3_1.kenshi, p4_2.kenshi]
+          [p1_1.kenshi, p3_2.kenshi],
+          [p2_1.kenshi, p4_2.kenshi],
+          [p3_1.kenshi, p1_2.kenshi],
+          [p4_1.kenshi, p2_2.kenshi]
         ])
       end
 
@@ -174,23 +174,23 @@ RSpec.describe IndividualCategoryBracketBuilder do
       let!(:p3_1) { create_qualified_participation(pool_number: 3, pool_rank: 1) }
       let!(:p3_2) { create_qualified_participation(pool_number: 3, pool_rank: 2) }
 
-      it "byes the strongest (one per half) and draws the rest cross-pool" do
+      it "byes the first winner of each pool-block and draws the rest cross-pool" do
         fights = described_class.new(category).call
         round_one = fights.select { |f| f.round == 1 }.sort_by(&:position)
 
         expect(round_one.map { |f| [f.fighter_1, f.fighter_2] }).to eq([
-          [p1_2.kenshi, p3_2.kenshi],
-          [p2_1.kenshi, nil],
           [p1_1.kenshi, nil],
-          [p3_1.kenshi, p2_2.kenshi]
+          [p2_1.kenshi, p3_2.kenshi],
+          [p1_2.kenshi, p2_2.kenshi],
+          [p3_1.kenshi, nil]
         ])
       end
 
-      it "advances bye fighters via winner_or_bye under the spread layout" do
+      it "spreads byes across the pool range (pools 1 and 3, not 1 and 2)" do
         fights = described_class.new(category).call
         byes = fights.select { |f| f.round == 1 && f.bye? }
 
-        expect(byes.map(&:winner_or_bye)).to contain_exactly(p1_1.kenshi, p2_1.kenshi)
+        expect(byes.map(&:winner_or_bye)).to contain_exactly(p1_1.kenshi, p3_1.kenshi)
       end
     end
 

--- a/spec/models/individual_category_bracket_builder_spec.rb
+++ b/spec/models/individual_category_bracket_builder_spec.rb
@@ -17,16 +17,34 @@ RSpec.describe IndividualCategoryBracketBuilder do
       let!(:p4_1) { create_qualified_participation(pool_number: 4, pool_rank: 1) }
       let!(:p4_2) { create_qualified_participation(pool_number: 4, pool_rank: 2) }
 
-      it "places R1 fights via canonical 1-vs-N seeding" do
+      it "lays out R1 as a cross-pool draw with same-pool fighters split across halves" do
         fights = described_class.new(category).call
         round_one = fights.select { |f| f.round == 1 }.sort_by(&:position)
 
         expect(round_one.map { |f| [f.fighter_1, f.fighter_2] }).to eq([
-          [p1_1.kenshi, p4_2.kenshi],
-          [p4_1.kenshi, p1_2.kenshi],
-          [p2_1.kenshi, p3_2.kenshi],
-          [p3_1.kenshi, p2_2.kenshi]
+          [p2_1.kenshi, p1_2.kenshi],
+          [p4_1.kenshi, p3_2.kenshi],
+          [p1_1.kenshi, p2_2.kenshi],
+          [p3_1.kenshi, p4_2.kenshi]
         ])
+      end
+
+      it "splits each pool's rank-1 and rank-2 into opposite halves" do
+        fights = described_class.new(category).call
+        round_one = fights.select { |f| f.round == 1 }.sort_by(&:position)
+        midpoint = round_one.size / 2 # B/4: positions [0, midpoint) = top half
+
+        half_of = lambda do |pool, rank|
+          index = round_one.index do |f|
+            (f.fighter_1_pool_number == pool && f.fighter_1_pool_rank == rank) ||
+              (f.fighter_2_pool_number == pool && f.fighter_2_pool_rank == rank)
+          end
+          (index < midpoint) ? :top : :bottom
+        end
+
+        (1..4).each do |pool|
+          expect(half_of.call(pool, 1)).not_to eq(half_of.call(pool, 2))
+        end
       end
 
       it "wires round 2 fights to their parents in canonical bracket order" do
@@ -81,12 +99,15 @@ RSpec.describe IndividualCategoryBracketBuilder do
 
       it "fills in the slots whose pool_rank is known and leaves the rest empty" do
         fights = described_class.new(category).call
-        round_one = fights.select { |f| f.round == 1 }.sort_by(&:position)
+        round_one = fights.select { |f| f.round == 1 }
 
-        expect(round_one.first.fighter_1).to eq p1_1.kenshi
-        expect(round_one.first.fighter_2).to be_nil
-        expect(round_one.last.fighter_1).to eq p2_1.kenshi
-        expect(round_one.last.fighter_2).to be_nil
+        slot_1_1 = round_one.find { |f| f.fighter_1_pool_number == 1 && f.fighter_1_pool_rank == 1 }
+        slot_2_1 = round_one.find { |f| f.fighter_1_pool_number == 2 && f.fighter_1_pool_rank == 1 }
+
+        expect(slot_1_1.fighter_1).to eq p1_1.kenshi
+        expect(slot_1_1.fighter_2).to be_nil
+        expect(slot_2_1.fighter_1).to eq p2_1.kenshi
+        expect(slot_2_1.fighter_2).to be_nil
       end
     end
 
@@ -105,9 +126,11 @@ RSpec.describe IndividualCategoryBracketBuilder do
         described_class.new(category).call
 
         expect(category.fights.order(:id).pluck(:id)).to eq fight_ids_before
-        round_one = category.fights.where(round: 1).order(:position)
-        expect(round_one.first.fighter_2).to eq p2_2.kenshi
-        expect(round_one.last.fighter_2).to eq p1_2.kenshi
+        round_one = category.fights.where(round: 1)
+        slot_1_2 = round_one.find { |f| f.fighter_2_pool_number == 1 && f.fighter_2_pool_rank == 2 }
+        slot_2_2 = round_one.find { |f| f.fighter_2_pool_number == 2 && f.fighter_2_pool_rank == 2 }
+        expect(slot_1_2.fighter_2).to eq p1_2.kenshi
+        expect(slot_2_2.fighter_2).to eq p2_2.kenshi
       end
 
       it "preserves recorded winners when filling in new slots" do
@@ -143,9 +166,36 @@ RSpec.describe IndividualCategoryBracketBuilder do
       end
     end
 
-    describe "rank-1 fighters never face each other in round 1" do
+    context "with 3 pools fully ranked" do
+      let!(:p1_1) { create_qualified_participation(pool_number: 1, pool_rank: 1) }
+      let!(:p1_2) { create_qualified_participation(pool_number: 1, pool_rank: 2) }
+      let!(:p2_1) { create_qualified_participation(pool_number: 2, pool_rank: 1) }
+      let!(:p2_2) { create_qualified_participation(pool_number: 2, pool_rank: 2) }
+      let!(:p3_1) { create_qualified_participation(pool_number: 3, pool_rank: 1) }
+      let!(:p3_2) { create_qualified_participation(pool_number: 3, pool_rank: 2) }
+
+      it "byes the strongest (one per half) and draws the rest cross-pool" do
+        fights = described_class.new(category).call
+        round_one = fights.select { |f| f.round == 1 }.sort_by(&:position)
+
+        expect(round_one.map { |f| [f.fighter_1, f.fighter_2] }).to eq([
+          [p2_1.kenshi, nil],
+          [p1_2.kenshi, p3_2.kenshi],
+          [p1_1.kenshi, nil],
+          [p3_1.kenshi, p2_2.kenshi]
+        ])
+      end
+
+      it "advances bye fighters via winner_or_bye under the spread layout" do
+        fights = described_class.new(category).call
+        byes = fights.select { |f| f.round == 1 && f.bye? }
+
+        expect(byes.map(&:winner_or_bye)).to contain_exactly(p1_1.kenshi, p2_1.kenshi)
+      end
+    end
+
+    describe "no two fighters from the same pool meet in round 1" do
       [
-        {pool_count: 1, out_of_pool: 2},
         {pool_count: 2, out_of_pool: 2},
         {pool_count: 3, out_of_pool: 2},
         {pool_count: 4, out_of_pool: 2},
@@ -170,11 +220,12 @@ RSpec.describe IndividualCategoryBracketBuilder do
 
           fights = described_class.new(category).call
           round_one = fights.select { |f| f.round == 1 }
-          rank_one_vs_rank_one = round_one.select { |f|
-            f.fighter_1_pool_rank == 1 && f.fighter_2_pool_rank == 1
+          same_pool = round_one.select { |f|
+            f.fighter_1_pool_number.present? &&
+              f.fighter_1_pool_number == f.fighter_2_pool_number
           }
 
-          expect(rank_one_vs_rank_one).to be_empty
+          expect(same_pool).to be_empty
         end
       end
     end
@@ -216,6 +267,31 @@ RSpec.describe IndividualCategoryBracketBuilder do
 
       expect(category.fights.where.not(winner_id: nil)).to be_empty
     end
+
+    it "builds a single one-fighter fight for one qualifier" do
+      solo = create(:individual_category, cup: cup, pool_size: 3, out_of_pool: 1)
+      participation = create(:participation, solo_attrs_for(solo, pool_number: 1, pool_rank: 1))
+
+      fights = described_class.new(solo).call
+
+      expect(fights.size).to eq 1
+      expect(fights.first.round).to eq 1
+      expect(fights.first.fighter_1).to eq participation.kenshi
+      expect(fights.first.fighter_2).to be_nil
+    end
+
+    it "places every qualifier for a single pool with out_of_pool 3 (clash unavoidable)" do
+      single = create(:individual_category, cup: cup, pool_size: 4, out_of_pool: 3)
+      (1..3).each do |pool_rank|
+        create(:participation, solo_attrs_for(single, pool_number: 1, pool_rank: pool_rank))
+      end
+
+      fights = described_class.new(single).call
+      round_one = fights.select { |f| f.round == 1 }
+      placed = round_one.flat_map { |f| [f.fighter_1_pool_rank, f.fighter_2_pool_rank] }.compact
+
+      expect(placed.sort).to eq [1, 2, 3]
+    end
   end
 
   context "when the category has pool fights" do
@@ -235,11 +311,40 @@ RSpec.describe IndividualCategoryBracketBuilder do
     end
   end
 
+  describe "cross-pool matching fallback" do
+    # The greedy pass is a heuristic that can leave a same-pool pair even when a
+    # valid cross-pool matching exists; grouped_cross_pool is the guaranteed
+    # fallback. The half-split keeps such a `rest` from arising through the
+    # public path (a pool's ranks are spread across halves), so this exercises
+    # the safety net directly.
+    it "resolves a rest the greedy pass cannot pair without a clash" do
+      builder = described_class.new(category)
+      slot = lambda do |pool, rank|
+        IndividualCategoryBracketBuilder::Slot.new(pool_number: pool, pool_rank: rank, participation: nil)
+      end
+      # pools [1, 2, 3, 2]: greedy pairs 2.1 vs 2.2 (same pool); grouped resolves it.
+      rest = [slot.call(1, 1), slot.call(2, 1), slot.call(3, 1), slot.call(2, 2)]
+
+      greedy = builder.send(:greedy_cross_pool, rest.dup)
+      expect(builder.send(:same_pool?, greedy)).to be(true) # greedy alone clashes
+
+      fights = builder.send(:cross_pool_match, rest)
+
+      expect(fights.flatten.map { |s| [s.pool_number, s.pool_rank] })
+        .to contain_exactly([1, 1], [2, 1], [3, 1], [2, 2])
+      expect(fights.any? { |a, b| a.pool_number == b.pool_number }).to be(false)
+    end
+  end
+
   def create_qualified_participation(pool_number:, pool_rank:)
     create(:participation,
       category: category,
       pool_number: pool_number,
       pool_position: pool_rank,
       pool_rank: pool_rank)
+  end
+
+  def solo_attrs_for(category, pool_number:, pool_rank:)
+    {category: category, pool_number: pool_number, pool_position: pool_rank, pool_rank: pool_rank}
   end
 end

--- a/spec/models/smart_pooler_spec.rb
+++ b/spec/models/smart_pooler_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe SmartPooler do
       .each_with_object({}) { |p, h| h[p.kenshi_id] = p.pool_number }
   end
 
+  # Sorted pool numbers of the short pools (fewer than pool_size participants).
+  def short_pool_numbers
+    pooled.select { |_number, participations| participations.size < pool_size }.keys.sort
+  end
+
   describe "#set_pools" do
     context "pool sizing with 13 participants and pool_size 4" do
       let(:pool_size) { 4 }
@@ -53,10 +58,35 @@ RSpec.describe SmartPooler do
       it "fills every participant into exactly one pool" do
         expect(pooled.values.sum(&:size)).to eq 13
       end
+    end
 
-      it "places the short (pool_size - 1) pools at the lowest pool numbers" do
-        sizes_by_number = pooled.transform_values(&:size)
-        expect(sizes_by_number).to eq({1 => 3, 2 => 3, 3 => 3, 4 => 4})
+    # Short pools head the bracket's halves/quarters rather than clustering at
+    # the top, so the byes/easier pools are spread evenly across the bracket.
+    context "spreading short pools across the bracket" do
+      context "with 2 short pools among 8" do
+        let(:pool_size) { 4 }
+
+        before do
+          30.times { add_participant } # 8 pools: 6 of size 4, 2 of size 3
+          described_class.new(category).set_pools
+        end
+
+        it "heads each half (pools #1 and #5)" do
+          expect(short_pool_numbers).to eq [1, 5]
+        end
+      end
+
+      context "with 4 short pools among 8" do
+        let(:pool_size) { 5 }
+
+        before do
+          36.times { add_participant } # 8 pools: 4 of size 5, 4 of size 4
+          described_class.new(category).set_pools
+        end
+
+        it "heads each quarter (pools #1, #3, #5 and #7)" do
+          expect(short_pool_numbers).to eq [1, 3, 5, 7]
+        end
       end
     end
 

--- a/spec/models/smart_pooler_spec.rb
+++ b/spec/models/smart_pooler_spec.rb
@@ -4,28 +4,175 @@ require "rails_helper"
 
 RSpec.describe SmartPooler do
   let!(:cup) { create(:cup) }
-  let(:smart_pooler) {
-    described_class.new(individual_category)
-  }
-  let!(:individual_category) {
-    create(:individual_category, name: "open", pool_size: 3, out_of_pool: 2, cup: cup)
+  let(:pool_size) { 4 }
+  let(:category) {
+    create(:individual_category, name: "open", pool_size: pool_size, out_of_pool: 2, cup: cup)
   }
 
-  24.times do |i|
-    let!("participation#{i + 1}") {
-      begin
-        kenshi = create(:kenshi, cup: cup)
-      rescue
-        Rails.logger.info("retries to create kenshi: SmartPooler spec, line 14")
-        retry
-      end
-      create(:participation, category: individual_category, kenshi: kenshi)
-    }
+  # Endless counter giving each kenshi unique names so validations never collide.
+  let(:sequence) { (1..).each }
+
+  # Creates one participation with a kenshi of the given grade/club.
+  def add_participant(grade: "kyu", club: nil)
+    n = sequence.next
+    club ||= create(:club)
+    kenshi = create(:kenshi, cup: cup, grade: grade, club: club,
+      first_name: "First#{n}", last_name: "Last#{n}")
+    create(:participation, category: category, kenshi: kenshi)
   end
 
-  before { smart_pooler.set_pools }
+  # {pool_number => [participations]} read fresh from the database.
+  def pooled
+    category.participations.includes(:kenshi).where.not(pool_number: nil).group_by(&:pool_number)
+  end
 
-  it { expect(individual_category.pools.size).to eq 8 }
-  it { expect(individual_category.data).to be_a Hash }
-  it { expect(individual_category.data.keys).to eq [:fights] }
+  def pool_number_by_kenshi
+    category.participations.where.not(pool_number: nil)
+      .each_with_object({}) { |p, h| h[p.kenshi_id] = p.pool_number }
+  end
+
+  describe "#set_pools" do
+    context "pool sizing with 13 participants and pool_size 4" do
+      let(:pool_size) { 4 }
+
+      before do
+        13.times { add_participant }
+        described_class.new(category).set_pools
+      end
+
+      it "creates ceil(N / pool_size) pools" do
+        expect(pooled.keys.sort).to eq [1, 2, 3, 4]
+      end
+
+      it "never exceeds pool_size and keeps sizes within one of each other" do
+        sizes = pooled.values.map(&:size)
+        expect(sizes.max).to be <= pool_size
+        expect(sizes.max - sizes.min).to be <= 1
+      end
+
+      it "fills every participant into exactly one pool" do
+        expect(pooled.values.sum(&:size)).to eq 13
+      end
+
+      it "places the short (pool_size - 1) pools at the lowest pool numbers" do
+        sizes_by_number = pooled.transform_values(&:size)
+        expect(sizes_by_number).to eq({1 => 3, 2 => 3, 3 => 3, 4 => 4})
+      end
+    end
+
+    context "club separation when each club fits within the pool count" do
+      let(:pool_size) { 4 }
+
+      before do
+        shared = create(:club)
+        2.times { add_participant(club: shared) } # two pools, two members -> splittable
+        6.times { add_participant }
+        described_class.new(category).set_pools
+      end
+
+      it "never places two members of the same club in one pool" do
+        pooled.each_value do |participations|
+          club_ids = participations.map { |p| p.kenshi.club_id }
+          expect(club_ids).to eq club_ids.uniq
+        end
+      end
+    end
+
+    context "club separation when a club has more members than pools" do
+      let(:pool_size) { 3 }
+      let!(:big_club) { create(:club) }
+
+      before do
+        3.times { add_participant(club: big_club) } # 3 members, only 2 pools
+        3.times { add_participant }
+        described_class.new(category).set_pools
+      end
+
+      it "spreads the club as evenly as possible across pools" do
+        per_pool = pooled.values.map { |ps| ps.count { |p| p.kenshi.club_id == big_club.id } }
+        expect(per_pool.max).to be <= 2 # ceil(3 members / 2 pools)
+      end
+    end
+
+    context "grade homogeneity with strong and weak fighters" do
+      let(:pool_size) { 4 }
+
+      before do
+        2.times { add_participant(grade: "5Dan") }
+        6.times { add_participant(grade: "kyu") }
+        described_class.new(category).set_pools
+      end
+
+      it "separates the strongest fighters across pools" do
+        strong = category.participations.includes(:kenshi).select { |p| p.kenshi.grade == "5Dan" }
+        expect(strong.map(&:pool_number).uniq.size).to eq 2
+      end
+
+      it "balances total strength across pools" do
+        totals = pooled.values.map { |ps| ps.sum { |p| p.kenshi.grade.to_i } }
+        expect(totals.max - totals.min).to be <= 5
+      end
+    end
+
+    context "determinism with an injected RNG" do
+      let(:pool_size) { 3 }
+
+      before do
+        9.times { |i| add_participant(grade: %w[kyu 1Dan 2Dan][i % 3]) }
+      end
+
+      it "produces the same assignment for the same seed" do
+        described_class.new(category, random: Random.new(123)).set_pools
+        first = pool_number_by_kenshi
+        described_class.new(category, random: Random.new(123)).set_pools
+        expect(pool_number_by_kenshi).to eq first
+      end
+    end
+
+    context "when pool_size is 1" do
+      let(:pool_size) { 1 }
+
+      before do
+        4.times { add_participant }
+        described_class.new(category).set_pools
+      end
+
+      it "assigns no pools" do
+        expect(category.participations.where.not(pool_number: nil)).to be_empty
+      end
+    end
+
+    context "when there are no participants" do
+      it "does nothing without error" do
+        expect { described_class.new(category).set_pools }.not_to raise_error
+      end
+    end
+
+    context "re-pooling after pools already exist" do
+      let(:pool_size) { 3 }
+
+      before { 6.times { add_participant } }
+
+      it "clears stale pool assignments when pooling is disabled" do
+        described_class.new(category).set_pools
+        expect(pooled).not_to be_empty
+        category.update!(pool_size: 1)
+        described_class.new(category).set_pools
+        expect(category.participations.where.not(pool_number: nil)).to be_empty
+      end
+    end
+
+    context "backwards compatibility: 24 participants, pool_size 3" do
+      let(:pool_size) { 3 }
+
+      before do
+        24.times { add_participant }
+        described_class.new(category).set_pools
+      end
+
+      it "creates 8 pools" do
+        expect(category.pools.size).to eq 8
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Two related improvements to how individual categories go from pools to an elimination bracket. Both are fully tested.

### Pool generation — `SmartPooler`
- Rewrote `SmartPooler` for a balanced, club-aware distribution.
- Spread short pools across bracket sections.

### Bracket seeding — `IndividualCategoryBracketBuilder`
Reworked how the single-elimination bracket is drawn from pool results so that:

- **No two qualifiers from the same pool meet in round 1** (the original bug: `17.1 vs 17.2`).
- **Each pool's rank-1 and rank-2 land in opposite halves** of the bracket, so they can only meet in the final.
- **Round-1 fights read in pool-number order** — the leading-fighter column goes `1, 2, 3, …` within each half.
- **Byes are spread across the pool range** instead of always landing on the lowest-numbered pools — e.g. 31 pools → byes from pools 1 & 17; 4 byes → 1, 9, 17, 25.

How it works: pools are split into a low block / high block for the half assignment (low pools' winners go to the top half, high pools' to the bottom, runners-up mirrored); within each half, byes go to evenly-spaced winners and the remaining entries are matched cross-pool, then ordered by leading fighter. A consequence of the block split is that round-1 opponents are now "far-pool" (a low pool's winner vs a high-pool runner-up) rather than the adjacent pool.

Verified against an exhaustive reference simulation over every pool count 1–64 × `out_of_pool` 1–4: every entry placed exactly once, no avoidable same-pool round 1, and rank-1/rank-2 always in opposite halves. The one documented edge: a small field in a much larger bracket (more byes than pools) spills byes onto runners-up, so a pool can receive more than one bye.

## Testing
- `bin/rspec spec/models/individual_category_bracket_builder_spec.rb spec/models/smart_pooler_spec.rb spec/services/bracket_display_numbering_spec.rb spec/requests/admin/individual_categories_bracket_spec.rb` → 53 examples, 0 failures.
- `bin/rubocop` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)