### PR TITLE
Team category: encounter scoring + pools + inline editing (Layers A–B.2)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,15 +45,13 @@ gem "prawn-table"
 gem "bootsnap", require: false
 gem "rack-cors"
 
-# Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
-
 # activeadmin
 gem "activeadmin"
 
 # ActiveStorage and Image processing
 gem "aws-sdk-s3"
 gem "image_processing"
+gem "ruby-vips"
 
 # ViewComponent
 gem "view_component"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,7 +318,6 @@ GEM
     marcel (1.2.1)
     matrix (0.4.3)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
@@ -335,9 +334,6 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.3)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
     observer (0.1.2)
@@ -520,6 +516,9 @@ GEM
       prism (>= 1.2, < 2.0)
       rbs (>= 3, < 5)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.3.0)
+      ffi (~> 1.12)
+      logger
     ruby2_keywords (0.0.5)
     rubyzip (3.3.1)
     sassc (2.4.0)
@@ -642,7 +641,6 @@ GEM
 
 PLATFORMS
   arm64-darwin-25
-  ruby
 
 DEPENDENCIES
   active_record_doctor
@@ -689,6 +687,7 @@ DEPENDENCIES
   rubocop-rails_config
   rubocop-rspec
   ruby-lsp
+  ruby-vips
   sassc-rails
   selenium-webdriver
   shoulda-matchers

--- a/app/admin/individual_category.rb
+++ b/app/admin/individual_category.rb
@@ -68,9 +68,9 @@ ActiveAdmin.register IndividualCategory, as: "IndividualCategory" do
       row :out_of_pool
       row :gender_restriction
     end
-    if category.pools.present?
+    if category.pool_size.to_i > 1
       panel "Pools" do
-        if category.pool_fights.empty?
+        if category.pools.any? && category.pool_fights.empty?
           div do
             span link_to("Generate pool fights",
               generate_pool_fights_admin_individual_category_path(category),
@@ -78,9 +78,14 @@ ActiveAdmin.register IndividualCategory, as: "IndividualCategory" do
               data: {confirm: "Generate the cyclic match list for all pools?"})
           end
         end
-        category.pools.sort_by(&:number).each do |pool|
-          render PoolComponent.new(category: category, pool_number: pool.number, admin: true, pool: pool)
-        end
+        # Always rendered (even with zero pools) so the first new pool card can
+        # land. The pool-membership controller re-renders this same partial to
+        # add a new pool, so the container markup lives in one place.
+        render partial: "admin/individual_categories/pools", locals: {category: category}
+        # Late registrants (pool_number nil): drag onto a pool or use the
+        # per-row "Add to…" select. Renders an empty container when there are
+        # none, and lists every participant before any pool is generated.
+        render IndividualPoolUnpooledComponent.new(category: category)
       end
     end
 
@@ -106,7 +111,7 @@ ActiveAdmin.register IndividualCategory, as: "IndividualCategory" do
       render CompetitionTreeComponent.new(category: category, admin: true)
     end
 
-    if category.participations.no_pool.present?
+    if category.pool_size.to_i <= 1 && category.participations.no_pool.present?
       panel "Participations without pool number" do
         table_for category.participations.no_pool do |participation|
           column :full_name do |participation|

--- a/app/admin/team.rb
+++ b/app/admin/team.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Team, as: "Team" do
-  permit_params :name, :cup, :team_category_id, :rank
+  permit_params :name, :cup, :team_category_id, :rank, :seed, :pool_number, :pool_position, :pool_rank
 
   controller do
     def scoped_collection
@@ -87,6 +87,7 @@ ActiveAdmin.register Team, as: "Team" do
       f.input :team_category, collection: TeamCategory.all.map { |tc| ["#{tc.name} (#{tc.cup})", tc.id] }
       f.input :name
       f.input :rank
+      f.input :seed, hint: "1 = champion … 4 = fourth medal; leave blank for unseeded"
     end
     f.actions
   end

--- a/app/admin/team_category.rb
+++ b/app/admin/team_category.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register TeamCategory do
-  permit_params :name, :pool_size, :out_of_pool, :min_age, :max_age, :gender_restriction,
+  permit_params :name, :team_size, :pool_size, :out_of_pool, :min_age, :max_age, :gender_restriction,
     :description_en, :description_fr, :cup_id
 
   form do |f|
@@ -11,8 +11,10 @@ ActiveAdmin.register TeamCategory do
       f.input :name
       f.input :description_en
       f.input :description_fr
-      f.input :pool_size
-      f.input :out_of_pool
+      f.input :team_size, as: :select, collection: [3, 5], include_blank: false,
+        hint: "Fighters per team (positional bouts per encounter)."
+      f.input :pool_size, hint: "Blank or 1 = bracket-only (teams go straight to the elimination bracket)."
+      f.input :out_of_pool, hint: "Qualifiers per pool; ignored for bracket-only categories."
       f.input :min_age
       f.input :max_age
       f.input :gender_restriction,
@@ -50,6 +52,7 @@ ActiveAdmin.register TeamCategory do
       row :cup
       row :description_en
       row :description_fr
+      row :team_size
       row :pool_size
       row :out_of_pool
       row :gender_restriction
@@ -84,6 +87,108 @@ ActiveAdmin.register TeamCategory do
         end
       end
     end
+    # Render the Pools panel for every pooled category, even before pools exist,
+    # so the unpooled-team / new-pool UI stays reachable for late registrants and
+    # initial pool creation. The _pools partial renders nothing when empty.
+    if category.pool_size.to_i > 1
+      panel "Pools" do
+        render partial: "admin/team_categories/pools", locals: {team_category: category}
+        # Late registrants (pool_number nil): drag onto a pool or use the
+        # per-row "Add to…" select. Renders an empty container when there are none.
+        render TeamPoolUnpooledComponent.new(team_category: category)
+      end
+    end
+    if category.bracket_encounters.any?
+      panel "Bracket" do
+        div do
+          # stream-link POSTs via fetch and renders the returned Turbo Stream in
+          # place, so the bracket rebuilds without a full-page navigation that
+          # would scroll back to the top. (A plain link here would be turned into
+          # a full-page form submit by ActiveAdmin's jquery_ujs.)
+          unless category.bracket_only?
+            span(link_to("Update bracket", generate_bracket_admin_team_category_path(category),
+              data: {controller: "stream-link", action: "stream-link#submit"}))
+            span " | "
+          end
+          rebuild_confirm = if category.bracket_only?
+            "Redraw the bracket? Scores are lost."
+          else
+            "Rebuild the bracket from current standings? Scores on rebuilt encounters are lost."
+          end
+          span(link_to("Force rebuild", generate_bracket_admin_team_category_path(category, rebuild: 1),
+            data: {controller: "stream-link", action: "stream-link#submit",
+                   stream_link_confirm_value: rebuild_confirm}))
+          span " | "
+          span(link_to("Download PDF", bracket_pdf_admin_team_category_path(category)))
+        end
+        render EncounterTreeComponent.new(team_category: category, admin: true)
+        # Encounter editors load here (tree cards target this frame); kept as a
+        # sibling of the tree frame so tree broadcasts can't wipe an open editor.
+        # The editor scrolls itself into view on load (encounter_panel controller).
+        text_node helpers.turbo_frame_tag(helpers.dom_id(category, :encounter_panel))
+      end
+    end
+  end
+
+  member_action :generate_pools, method: :post do
+    category = TeamCategory.find(params[:id])
+    if category.bracket_only?
+      return redirect_to admin_team_category_path(category), alert: "Bracket-only category — no pool phase." # rubocop:disable Rails/I18nLocaleTexts
+    end
+
+    category.set_team_pools
+    redirect_to admin_team_category_path(category), notice: "Pools generated." # rubocop:disable Rails/I18nLocaleTexts
+  end
+
+  member_action :generate_pool_encounters, method: :post do
+    category = TeamCategory.find(params[:id])
+    if category.bracket_only?
+      return redirect_to admin_team_category_path(category), alert: "Bracket-only category — no pool phase." # rubocop:disable Rails/I18nLocaleTexts
+    end
+
+    PoolEncounterGenerator.new(category).call
+    redirect_to admin_team_category_path(category), notice: "Pool encounters generated." # rubocop:disable Rails/I18nLocaleTexts
+  end
+
+  member_action :generate_bracket, method: :post do
+    category = TeamCategory.find(params[:id])
+    TeamCategoryBracketBuilder.new(category, rebuild_started: params[:rebuild].present?).call
+    respond_to do |format|
+      # Swap just the bracket tree in place (stream-link fetches this) so the
+      # admin keeps their scroll position instead of a full-page redirect.
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace(
+          helpers.dom_id(category, :encounter_tree),
+          partial: "team_bracket_trees/team_bracket_tree",
+          locals: {team_category: category}
+        )
+      end
+      format.html { redirect_to admin_team_category_path(category), notice: "Bracket generated." } # rubocop:disable Rails/I18nLocaleTexts
+    end
+  end
+
+  action_item :generate_pools, only: :show, if: proc { !resource.bracket_only? } do
+    link_to "Generate pools", generate_pools_admin_team_category_path(team_category),
+      method: :post, data: {confirm: "Redraw all pools? Manual pool assignments are lost."}
+  end
+
+  action_item :generate_pool_encounters, only: :show, if: proc { !resource.bracket_only? } do
+    link_to "Generate pool encounters", generate_pool_encounters_admin_team_category_path(team_category),
+      method: :post
+  end
+
+  action_item :generate_bracket, only: :show do
+    link_to "Generate bracket", generate_bracket_admin_team_category_path(team_category),
+      method: :post
+  end
+
+  member_action :bracket_pdf do
+    @team_category = TeamCategory.find params[:id]
+    pdf = TeamCategoryBracketPdf.new(@team_category)
+    send_data pdf.render,
+      filename: "#{@team_category.name.parameterize(separator: "_")}_bracket.pdf",
+      type: "application/pdf",
+      disposition: "inline"
   end
 
   member_action :pdf do
@@ -104,6 +209,10 @@ ActiveAdmin.register TeamCategory do
 
   action_item :new_document, only: :show do
     link_to("New document", new_admin_team_category_document_path(team_category))
+  end
+
+  action_item :encounters, only: :show do
+    link_to "Encounters", admin_team_category_encounters_path(team_category)
   end
 
   # collection_action :pdfs do

--- a/app/assets/stylesheets/components/pool_card.css
+++ b/app/assets/stylesheets/components/pool_card.css
@@ -4,11 +4,98 @@
   border-radius: 0.5rem;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
   margin-block: 1rem;
-  padding: 1rem;
+  padding: 0.75rem;
+}
+
+/* Highlight a pool card while a dragged team hovers over it as a drop target. */
+.pool-card--drop {
+  outline: 2px dashed #de7012;
+  outline-offset: 2px;
+}
+
+/* Drag grip in a standings row + the accessible "Move to" select. */
+.pool-standings__grip {
+  margin-right: 0.375rem;
+}
+
+.pool-standings__sr-only {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.pool-standings td.pool-standings__move {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.pool-standings__move-select {
+  border: 1px solid #D6D4D0;
+  border-radius: 0.25rem;
+  color: #44403A;
+  font-size: 0.75rem;
+  padding: 0.125rem 0.25rem;
+}
+
+/* Late registrants waiting to join a pool. */
+.pool-unpooled {
+  background: #fef6ef;
+  border: 1px dashed #eb862e;
+  border-radius: 0.375rem;
+  margin-top: 0.75rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.pool-unpooled__title {
+  color: #44403A;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  margin: 0 0 0.5rem;
+  text-transform: uppercase;
+}
+
+.pool-unpooled__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.pool-unpooled__team {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.pool-unpooled__name {
+  font-weight: 600;
+  margin-right: auto;
+}
+
+.pool-unpooled__hint {
+  color: #8a6d3b;
+  font-size: 0.8125rem;
+  margin: 0;
 }
 
 .pool-card button, .pool-card input {
   text-shadow: none;
+}
+
+/* Title left, the "Regenerate" reset button pinned top-right. */
+.pool-card__header {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
+  margin: 0 0 0.5rem;
 }
 
 .pool-card__title {
@@ -16,7 +103,7 @@
   font-size: 1rem;
   font-weight: 700;
   letter-spacing: -0.01em;
-  margin: 0 0 0.75rem;
+  margin: 0;
 }
 
 .pool-card__alert {
@@ -39,9 +126,9 @@
 .pool-matches {
   display: flex;
   flex-direction: column;
-  gap: 0.625rem;
+  gap: 0.375rem;
   list-style: none;
-  margin: 0 0 1rem;
+  margin: 0 0 0.75rem;
   padding: 0;
 }
 
@@ -49,7 +136,7 @@
   background: #fcfaf8;
   border: 1px solid #E8E5E3;
   border-radius: 0.375rem;
-  padding: 0.5rem 0.75rem;
+  padding: 0.375rem 0.5rem;
 }
 
 .pool-match--tiebreaker {
@@ -57,24 +144,63 @@
   border-color: #eb862e;
 }
 
+/* Three tracks — position (left), result (centered), toggle (right) — so the
+   verdict sits dead-center on the line regardless of the label/name widths. */
 .pool-match__header {
+  align-items: center;
   color: #75716C;
-  font-size: 0.75rem;
+  display: grid;
+  font-size: 0.6875rem;
   font-weight: 600;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto 1fr;
   letter-spacing: 0.04em;
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.25rem;
   text-transform: uppercase;
+}
+
+/* Hikiwake toggle lives in the bout header (right of the position label) so it
+   no longer needs its own row below the sides. */
+.pool-match__hikiwake-form {
+  grid-column: 3;
+  justify-self: end;
+  margin: 0;
+}
+
+.pool-match__hikiwake {
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 0.25rem;
+  color: #44403A;
+  cursor: pointer;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  padding: 0.0625rem 0.375rem;
+  text-transform: none;
+  white-space: nowrap;
+}
+
+.pool-match__hikiwake:not(.disabled):hover {
+  background: #575757;
+  color: #fff;
+}
+
+.pool-match__hikiwake--active {
+  background: #ecfdf3;
+  border-color: #15803d;
+  color: #15803d;
 }
 
 .pool-match__sides {
   display: grid;
-  gap: 0.5rem;
+  gap: 0.375rem;
   grid-template-columns: 1fr 1fr;
 }
 
 .pool-match__side {
   border-radius: 0.25rem;
-  padding: 0.375rem 0.5rem;
+  padding: 0.25rem 0.375rem;
   position: relative;
 }
 
@@ -96,11 +222,34 @@
   align-items: center;
   display: flex;
   gap: 0.5rem;
-  margin-bottom: 0.375rem;
+  margin-bottom: 0.25rem;
 }
 
 .pool-match__side--fighter_2 .pool-match__row {
   flex-direction: row-reverse;
+}
+
+/* Drag handle for swapping fighters between positions within one team column.
+   The dropdowns stay the primary (and accessible) way to set a lineup; this is
+   a shortcut on top. */
+.pool-match__grip {
+  color: #A6A29D;
+  cursor: grab;
+  flex: none;
+  font-size: 0.875rem;
+  line-height: 1;
+  user-select: none;
+}
+
+.pool-match__grip:active {
+  cursor: grabbing;
+}
+
+/* Highlight the card a dragged fighter would land on. */
+.pool-match__row--drop {
+  border-radius: 0.25rem;
+  outline: 2px dashed #de7012;
+  outline-offset: 1px;
 }
 
 .pool-match__name {
@@ -114,13 +263,36 @@
   white-space: nowrap;
 }
 
+/* The fighter name slot doubles as the lineup picker: selecting a fighter
+   auto-submits that team's lineup. */
+.pool-match__select {
+  background: #fff;
+  border: 1px solid #D6D4D0;
+  border-radius: 0.25rem;
+  color: #181512;
+  flex: 1;
+  font-size: 0.875rem;
+  font-weight: 600;
+  min-width: 0;
+  padding: 0.1875rem 0.375rem;
+}
+
+.pool-match__select:hover {
+  border-color: #A6A29D;
+}
+
+.pool-match__select:focus {
+  border-color: #de7012;
+  outline: none;
+}
+
 .pool-match__points {
   display: flex;
   flex-wrap: wrap;
   gap: 0.1875rem;
   list-style: none;
   margin: 0;
-  min-height: 1.25rem;
+  min-height: 0.875rem;
   padding: 0;
 }
 
@@ -195,7 +367,7 @@
   cursor: pointer;
   font-size: 0.6875rem;
   font-weight: 600;
-  padding: 0.1875rem 0;
+  padding: 0.125rem 0;
   width: 100%;
 }
 
@@ -214,12 +386,15 @@
   color: #1e3a8a;
 }
 
+/* Lives on the right of the bout header (next to the Match label), so it sits
+   on the top line rather than in its own row below the sides. */
 .pool-match__outcome {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
   gap: 0.25rem;
-  margin-top: 0.5rem;
+  justify-content: flex-end;
+  margin: 0;
 }
 
 .pool-match__outcome-form {
@@ -233,7 +408,12 @@
   color: #44403A;
   cursor: pointer;
   font-size: 0.75rem;
+  /* Don't inherit the header's uppercase/letter-spacing — keep button labels
+     ("Oetterli wins", "Draw", "Clear") in their natural casing. */
+  font-weight: 400;
+  letter-spacing: 0;
   padding: 0.25rem 0.5rem;
+  text-transform: none;
 }
 
 .pool-match__outcome-btn:not(.disabled):hover {
@@ -289,7 +469,7 @@
 }
 
 .pool-card__reset-form {
-  margin: 0 0 1rem;
+  margin: 0;
 }
 
 .pool-card__reset {
@@ -317,7 +497,7 @@
 .pool-standings th,
 .pool-standings td {
   border-bottom: 1px solid #E8E5E3;
-  padding: 0.375rem 0.5rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
 }
 
@@ -404,4 +584,274 @@
 
 .pool-standings__actions a {
   color: #de7012;
+}
+
+/* --- Team encounter panel ----------------------------------------------- */
+/* Reuses the .pool-match scoring layout above so a team encounter scores with
+   the same two-sided cards as an individual category pool. */
+
+.pool-encounter {
+  background: #fff;
+  border: 1px solid #E8E5E3;
+  border-radius: 0.375rem;
+  margin-block: 0.375rem;
+  padding: 0.375rem 0.75rem;
+}
+
+/* The <summary> is the encounter's header on the pool page and reads as a
+   scoreboard: each team name heads its column of fighters, with the score and
+   outcome centered beneath. The horizontal padding matches a card's content box
+   (1px border + 0.75rem padding) so the names line up with the columns below. */
+.pool-encounter > summary {
+  align-items: baseline;
+  column-gap: 0.75rem;
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  list-style: none;
+  padding: 0 calc(0.75rem + 1px);
+  position: relative;
+}
+
+.pool-encounter > summary::-webkit-details-marker {
+  display: none;
+}
+
+/* Disclosure caret, positioned out of the grid flow so it never shifts the
+   team names off their columns. */
+.pool-encounter > summary::before {
+  color: #75716C;
+  content: "▸";
+  font-size: 0.75rem;
+  left: 0;
+  position: absolute;
+  top: 0;
+}
+
+.pool-encounter[open] > summary::before {
+  content: "▾";
+}
+
+.encounter-summary__team {
+  color: #181512;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  grid-column: 1;
+  grid-row: 1;
+  letter-spacing: -0.01em;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.encounter-summary__team--right {
+  grid-column: 3;
+  text-align: right;
+}
+
+.encounter-summary__status {
+  color: #75716C;
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+  grid-column: 2;
+  grid-row: 1;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.pool-encounter[open] > summary {
+  border-bottom: 1px solid #E8E5E3;
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.375rem;
+}
+
+.encounter {
+  margin: 0;
+}
+
+.encounter__header {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+/* On the pool page the <summary> is the encounter's header, so the panel's own
+   title would duplicate it — hide it there. The standalone encounter page has
+   no summary, so the title still shows. */
+.pool-encounter .encounter__header {
+  display: none;
+}
+
+.encounter__title {
+  color: #181512;
+  font-size: 1.0625rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.encounter__tally {
+  color: #75716C;
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.encounter__alert {
+  background: #fee2e2;
+  border: 1px solid #fca5a5;
+  border-radius: 0.375rem;
+  color: #991b1b;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  margin: 0 0 0.75rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.encounter__verdict {
+  border-radius: 0.375rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+  padding: 0.375rem 0.625rem;
+}
+
+.encounter__verdict--win {
+  background: #ecfdf3;
+  color: #15803d;
+}
+
+.encounter__verdict--tie {
+  background: #fef6ef;
+  color: #de7012;
+}
+
+/* Centered on the bout header line; override the header's uppercase/tracking so
+   a fighter's name reads normally. */
+.pool-match__verdict {
+  color: #75716C;
+  font-weight: 700;
+  grid-column: 2;
+  justify-self: center;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.pool-match__verdict--win {
+  color: #15803d;
+}
+
+.lineups {
+  display: grid;
+  gap: 0.625rem;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  margin-top: 0.75rem;
+}
+
+.lineup {
+  background: #fcfaf8;
+  border: 1px solid #E8E5E3;
+  border-radius: 0.375rem;
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+}
+
+.lineup__title {
+  color: #75716C;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  margin: 0 0 0.5rem;
+  text-transform: uppercase;
+}
+
+.lineup__slots {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.lineup__select {
+  border: 1px solid #D6D4D0;
+  border-radius: 0.25rem;
+  font-size: 0.8125rem;
+  padding: 0.25rem 0.375rem;
+  width: 100%;
+}
+
+.lineup__submit {
+  background: #de7012;
+  border: 1px solid #de7012;
+  border-radius: 0.25rem;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.3125rem 0.75rem;
+}
+
+.lineup__submit:not(.disabled):hover {
+  background: #d16a0f;
+}
+
+/* Slot-swap forms: one per occupied side, aligned under that team's column
+   (same 1fr/1fr grid as .pool-match__sides). */
+.swap-team {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: 1fr 1fr;
+  margin-top: 0.75rem;
+}
+
+.swap-team__form {
+  align-items: center;
+  background: #fef6ef;
+  border: 1px dashed #eb862e;
+  border-radius: 0.375rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.swap-team__form--slot_1 {
+  grid-column: 1;
+}
+
+.swap-team__form--slot_2 {
+  grid-column: 2;
+  justify-content: flex-end;
+}
+
+.swap-team__label {
+  color: #44403A;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.swap-team__select {
+  border: 1px solid #D6D4D0;
+  border-radius: 0.25rem;
+  font-size: 0.8125rem;
+  padding: 0.25rem 0.375rem;
+}
+
+.swap-team__submit {
+  background: #de7012;
+  border: 1px solid #de7012;
+  border-radius: 0.25rem;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.3125rem 0.625rem;
+}
+
+.swap-team__submit:not(.disabled):hover {
+  background: #d16a0f;
 }

--- a/app/components/competition_tree_component.html.erb
+++ b/app/components/competition_tree_component.html.erb
@@ -18,7 +18,7 @@
           <h3 class="competition-tree__round competition-tree__round-title" style="left: <%= match_left(fights.first) %>px;">Round <%= round_number %></h3>
 
           <% fights.each do |fight| %>
-            <% next unless render_fight?(fight) %>
+            <% next unless render_node?(fight) %>
 
             <% if fight.bye? %>
               <% bye_slot = fight.bye_slot %>

--- a/app/components/competition_tree_component.rb
+++ b/app/components/competition_tree_component.rb
@@ -1,19 +1,14 @@
 # frozen_string_literal: true
 
 class CompetitionTreeComponent < ViewComponent::Base
+  include BracketLayout
+
   def initialize(category:, admin: false)
     @category = category
     @admin = admin
   end
 
   private attr_reader :category, :admin
-
-  CARD_WIDTH = 224
-  CARD_HEIGHT = 80
-  BYE_CARD_HEIGHT = 40
-  ROUND_GAP = 48
-  MATCH_GAP = 8
-  PADDING = 8
 
   private def fights
     @fights ||= begin
@@ -25,8 +20,17 @@ class CompetitionTreeComponent < ViewComponent::Base
     end
   end
 
-  private def rounds
-    @rounds ||= fights.group_by(&:round)
+  private def bracket_nodes
+    fights
+  end
+
+  private def node_parents(fight)
+    [fight.parent_fight_1, fight.parent_fight_2]
+  end
+
+  private def node_has_own_identity?(fight)
+    fight.fighter_1.present? || fight.fighter_2.present? ||
+      (fight.round == 1 && (fight.fighter_1_pool_number.present? || fight.fighter_2_pool_number.present?))
   end
 
   private def display_numbers
@@ -35,80 +39,6 @@ class CompetitionTreeComponent < ViewComponent::Base
 
   private def display_number(fight)
     display_numbers[fight.id]
-  end
-
-  private def canvas_width
-    return 0 if rounds.empty?
-
-    PADDING * 2 + rounds.keys.max * CARD_WIDTH + (rounds.keys.max - 1) * ROUND_GAP
-  end
-
-  private def canvas_height
-    return 0 if rounds.empty?
-
-    PADDING * 2 + first_round_slots * (CARD_HEIGHT + MATCH_GAP) - MATCH_GAP
-  end
-
-  private def first_round_slots
-    [rounds.fetch(1, []).size, 1].max
-  end
-
-  private def match_style(fight)
-    "left: #{match_left(fight)}px; top: #{match_top(fight)}px;"
-  end
-
-  private def match_left(fight)
-    PADDING + (fight.round - 1) * (CARD_WIDTH + ROUND_GAP)
-  end
-
-  private def match_top(fight)
-    height = fight.bye? ? BYE_CARD_HEIGHT : CARD_HEIGHT
-    PADDING + (fight_center_y(fight) - height / 2.0).round
-  end
-
-  private def fight_center_y(fight)
-    slot_height = CARD_HEIGHT + MATCH_GAP
-    span = 2**(fight.round - 1)
-    first_slot = (fight.position - 1) * span
-
-    slot_height * (first_slot + (span / 2.0)) - MATCH_GAP / 2.0
-  end
-
-  private def connector_paths
-    rounds.values.flatten.filter_map do |fight|
-      next unless render_fight?(fight)
-
-      parent_paths(fight)
-    end.flatten
-  end
-
-  private def parent_paths(fight)
-    connector_parents(fight).map do |parent_fight|
-      connector_path(parent_fight, fight)
-    end
-  end
-
-  private def connector_parents(fight)
-    parent_fights(fight).flat_map do |parent_fight|
-      visible_connector_parent(parent_fight)
-    end
-  end
-
-  private def visible_connector_parent(fight)
-    return [fight] if render_fight?(fight)
-    return connector_parents(fight) if hidden_pass_through_fight?(fight)
-
-    []
-  end
-
-  private def connector_path(parent_fight, fight)
-    start_x = match_left(parent_fight) + CARD_WIDTH
-    start_y = PADDING + fight_center_y(parent_fight).round
-    end_x = match_left(fight)
-    end_y = PADDING + fight_center_y(fight).round
-    elbow_x = start_x + (end_x - start_x) / 2
-
-    "M #{start_x} #{start_y} H #{elbow_x} V #{end_y} H #{end_x}"
   end
 
   private def tree_dom_id
@@ -173,62 +103,9 @@ class CompetitionTreeComponent < ViewComponent::Base
 
   private def visible_fighter_parent(fight)
     return if fight.blank?
-    return fight if render_fight?(fight)
+    return fight if render_node?(fight)
 
-    visible_connector_parent(fight).first if hidden_pass_through_fight?(fight)
-  end
-
-  private def render_fight?(fight)
-    rendered_fight_ids.fetch(fight.id) do
-      rendered_fight_ids[fight.id] = fight_has_direct_fighter?(fight) ||
-        fight_has_slot_identity?(fight) ||
-        render_forecasted_fight?(fight)
-    end
-  end
-
-  private def rendered_fight_ids
-    @rendered_fight_ids ||= {}
-  end
-
-  private def fight_has_direct_fighter?(fight)
-    fight.fighter_1.present? || fight.fighter_2.present?
-  end
-
-  private def fight_has_slot_identity?(fight)
-    fight.round == 1 &&
-      (fight.fighter_1_pool_number.present? || fight.fighter_2_pool_number.present?)
-  end
-
-  private def render_forecasted_fight?(fight)
-    parent_fights(fight).any? &&
-      parent_fights(fight).any? { |parent_fight| render_fight?(parent_fight) } &&
-      !hidden_pass_through_fight?(fight)
-  end
-
-  private def hidden_pass_through_fight?(fight)
-    pass_through_fight?(fight) && child_fights.fetch(fight.id, []).any?
-  end
-
-  private def pass_through_fight?(fight)
-    parents = parent_fights(fight)
-    return false unless parents.size > 1
-
-    parents.one? { |parent_fight| render_fight?(parent_fight) } &&
-      parents.any? { |parent_fight| !render_fight?(parent_fight) }
-  end
-
-  private def parent_fights(fight)
-    [fight.parent_fight_1, fight.parent_fight_2].compact
-  end
-
-  private def child_fights
-    @child_fights ||= rounds.values.flatten.each_with_object(Hash.new { |hash, key|
-      hash[key] = []
-    }) do |fight, children|
-      parent_fights(fight).each do |parent_fight|
-        children[parent_fight.id] << fight
-      end
-    end
+    visible_connector_parent(fight).first if hidden_pass_through_node?(fight)
   end
 
   private def points_for(fight, slot)

--- a/app/components/encounter_component.rb
+++ b/app/components/encounter_component.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+class EncounterComponent < ViewComponent::Base
+  include ActionView::RecordIdentifier
+
+  def initialize(encounter:, admin: false, alert: nil, auto_seed: false)
+    @encounter = encounter
+    @admin = admin
+    @alert = alert
+    @auto_seed = auto_seed
+    @result = encounter.result
+  end
+
+  attr_reader :encounter, :admin, :result, :alert
+
+  # data-* for the encounter container: the lineup controller, plus the seed
+  # endpoint it POSTs to on open when this is a freshly-opened editor with an
+  # unset, unpopulated side that has a suggestion to lay down.
+  def container_data
+    data = {controller: "lineup"}
+    data[:lineup_seed_url_value] = seed_path if seed_on_open?
+    data
+  end
+
+  def seed_on_open?
+    @auto_seed && admin && [1, 2].any? { |slot| seed_needed?(slot) }
+  end
+
+  # Reuse the association when the caller already preloaded it (pool view loads
+  # team_fights with kenshis/winner/fight_points up front); only eager-load here
+  # for the standalone/broadcast cases where the encounter arrives bare.
+  def fights
+    @fights ||= if encounter.team_fights.loaded?
+      encounter.team_fights.to_a
+    else
+      encounter.team_fights.includes(:kenshi_1, :kenshi_2, :winner, :fight_points).to_a
+    end
+  end
+
+  def regular_fights
+    fights.reject(&:daihyosen?)
+  end
+
+  # One card per roster position, whether or not its TeamFight row exists yet.
+  # A pool encounter is generated without bouts (they are created on first
+  # lineup assign), so we back the missing positions with unsaved placeholders
+  # — that gives every position its dropdowns up front, which is how a lineup
+  # gets entered now that the form lives in the table.
+  def position_rows
+    by_position = regular_fights.index_by(&:position)
+    (1..encounter.team_size).map do |position|
+      by_position[position] || TeamFight.new(encounter: encounter, position: position)
+    end
+  end
+
+  def daihyosen
+    fights.find(&:daihyosen?)
+  end
+
+  def teams
+    @teams ||= [encounter.resolved_team_1, encounter.resolved_team_2]
+  end
+
+  def both_teams_resolved?
+    teams.all?(&:present?)
+  end
+
+  # Kenshis selectable for each side's dropdown, keyed by team id and loaded once.
+  def team_kenshis
+    @team_kenshis ||= teams.compact.to_h { |team| [team.id, team.kenshis.to_a] }
+  end
+
+  # Pre-fill order for each side, used only while a side's lineup is unset: the
+  # dropdowns open showing the team's previous order (or roster order) instead
+  # of blank. A set side returns nil so its real picks — including deliberate
+  # blanks — are never overridden by a suggestion.
+  def suggestions
+    @suggestions ||= [1, 2].index_with do |slot|
+      # A prefill only appears where we also persist it (auto_seed) — otherwise
+      # picking the already-suggested fighter would no-op (no change event) and
+      # the bout would never be saved.
+      next nil unless admin && @auto_seed
+      next nil if encounter.public_send(:"lineup_#{slot}_set?")
+
+      EncounterLineupSuggestion.new(encounter).for_slot(slot)
+    end
+  end
+
+  # Worth seeding this side on open: not yet confirmed, no fighter placed there
+  # yet, and there is a suggestion to place. Uses the already-loaded fights so it
+  # adds no queries beyond the memoized suggestion.
+  private def seed_needed?(slot)
+    return false if encounter.public_send(:"lineup_#{slot}_set?")
+    return false if suggestions[slot].to_a.compact.empty?
+
+    fights.none? { |fight| !fight.daihyosen? && fight.public_send(:"kenshi_#{slot}_id").present? }
+  end
+
+  private def seed_path
+    helpers.admin_team_category_encounter_lineup_seed_path(encounter.team_category, encounter)
+  end
+
+  def tied?
+    result.complete? && result.winner.nil? && encounter.pool_number.blank?
+  end
+
+  def fighter_name(kenshi)
+    kenshi&.full_name || "—"
+  end
+
+  # Mirrors the individual pool fights so the scoring buttons read identically
+  # (M/K/D/T/I and △ for hansoku).
+  def point_codes
+    FightPoint::CODES
+  end
+end

--- a/app/components/encounter_component/encounter_component.html.erb
+++ b/app/components/encounter_component/encounter_component.html.erb
@@ -1,0 +1,38 @@
+<%# app/components/encounter_component/encounter_component.html.erb %>
+<%= tag.div id: dom_id(encounter), class: "encounter", data: container_data do %>
+  <header class="encounter__header">
+    <h2 class="encounter__title"><%= encounter.team_display_name(1) %> vs <%= encounter.team_display_name(2) %></h2>
+    <span class="encounter__tally">
+      wins <%= result.team_1_wins %>–<%= result.team_2_wins %>,
+      ippons <%= result.team_1_ippons %>–<%= result.team_2_ippons %>
+    </span>
+  </header>
+
+  <% if alert.present? %>
+    <p class="encounter__alert" role="alert"><%= alert %></p>
+  <% end %>
+
+  <% if result.winner %>
+    <p class="encounter__verdict encounter__verdict--win">Winner: <%= result.winner.name %></p>
+  <% elsif tied? %>
+    <p class="encounter__verdict encounter__verdict--tie">Tied — a daihyōsen is required.</p>
+  <% end %>
+
+  <% if both_teams_resolved? %>
+    <ol class="pool-matches">
+      <% position_rows.each do |fight| %>
+        <%= render "admin/encounters/match", encounter: encounter, fight: fight,
+              admin: admin, point_codes: point_codes, teams: teams, team_kenshis: team_kenshis,
+              suggestions: suggestions %>
+      <% end %>
+
+      <% if daihyosen %>
+        <%= render "admin/encounters/match", encounter: encounter, fight: daihyosen,
+              admin: admin, point_codes: point_codes, teams: teams, team_kenshis: team_kenshis,
+              suggestions: suggestions %>
+      <% end %>
+    </ol>
+  <% else %>
+    <p class="encounter__waiting">Waiting for both teams to be decided.</p>
+  <% end %>
+<% end %>

--- a/app/components/encounter_tree_component.rb
+++ b/app/components/encounter_tree_component.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+class EncounterTreeComponent < ViewComponent::Base
+  include ActionView::RecordIdentifier
+  include BracketLayout
+
+  def initialize(team_category:, admin: false)
+    @team_category = team_category
+    @admin = admin
+  end
+
+  private attr_reader :team_category, :admin
+
+  private def bracket_nodes
+    encounters
+  end
+
+  private def node_parents(encounter)
+    [encounter.parent_encounter_1, encounter.parent_encounter_2]
+  end
+
+  private def node_has_own_identity?(encounter)
+    encounter.team_1.present? || encounter.team_2.present? ||
+      (encounter.round == 1 &&
+        (encounter.team_1_pool_number.present? || encounter.team_2_pool_number.present?))
+  end
+
+  private def encounters
+    @encounters ||= begin
+      list = team_category.bracket_encounters
+        .includes(:team_1, :team_2, :winner, team_fights: :fight_points)
+        .bracket_order.to_a
+      Encounter.preload_parents(list)
+      list
+    end
+  end
+
+  private def display_numbers
+    @display_numbers ||= BracketDisplayNumbering.for(encounters)
+  end
+
+  private def display_number(encounter)
+    display_numbers[encounter.id]
+  end
+
+  private def team_name(encounter, slot)
+    team = encounter.public_send(:"resolved_team_#{slot}")
+    return team.name if team.present?
+
+    parent = visible_team_parent(encounter.public_send(:"parent_encounter_#{slot}"))
+    if parent.present?
+      return tag.em("Waiting for encounter #{display_number(parent)}", style: "color: #75716C;")
+    end
+
+    # A seeded-but-unresolved round-1 slot shows its seed via the pool-position
+    # prefix in the template; the name stays blank (mirrors CompetitionTreeComponent).
+    ""
+  end
+
+  private def seed_label(encounter, slot)
+    return unless encounter.round == 1
+
+    pool_number = encounter.public_send(:"team_#{slot}_pool_number")
+    pool_rank = encounter.public_send(:"team_#{slot}_pool_rank")
+    return if pool_number.blank? || pool_rank.blank?
+
+    "#{pool_number}.#{pool_rank}"
+  end
+
+  private def team_winner?(encounter, slot)
+    return false if encounter.winner.blank?
+
+    team = encounter.public_send(:"resolved_team_#{slot}")
+    team.present? && team == encounter.winner
+  end
+
+  private def score_line(encounter)
+    return if encounter.team_fights.empty?
+
+    result = encounter.result
+    "#{result.team_1_wins}–#{result.team_2_wins} (#{result.team_1_ippons}–#{result.team_2_ippons})"
+  end
+
+  private def visible_team_parent(encounter)
+    return if encounter.blank?
+    return encounter if render_node?(encounter)
+
+    visible_connector_parent(encounter).first if hidden_pass_through_node?(encounter)
+  end
+
+  private def encounter_path(encounter)
+    helpers.admin_team_category_encounter_path(team_category, encounter)
+  end
+
+  private def tree_dom_id
+    helpers.dom_id(team_category, :encounter_tree)
+  end
+
+  private def panel_dom_id
+    helpers.dom_id(team_category, :encounter_panel)
+  end
+end

--- a/app/components/encounter_tree_component/encounter_tree_component.html.erb
+++ b/app/components/encounter_tree_component/encounter_tree_component.html.erb
@@ -1,0 +1,58 @@
+<%# app/components/encounter_tree_component/encounter_tree_component.html.erb %>
+<%= helpers.turbo_frame_tag tree_dom_id do %>
+  <% if admin %>
+    <%= helpers.turbo_stream_from team_category, :encounter_tree %>
+  <% end %>
+  <div id="<%= tree_dom_id %>" class="competition-tree">
+    <% if rounds.empty? %>
+      <p class="competition-tree__empty">No bracket yet.</p>
+    <% else %>
+      <div class="competition-tree__viewport" style="width: <%= canvas_width %>px; height: <%= canvas_height %>px;">
+        <svg class="competition-tree__svg" width="<%= canvas_width %>" height="<%= canvas_height %>">
+          <% connector_paths.each do |path| %>
+            <path class="competition-tree__line" d="<%= path %>" fill="none" />
+          <% end %>
+        </svg>
+
+        <% rounds.each_value do |round_encounters| %>
+          <% round_encounters.each do |encounter| %>
+            <% next unless render_node?(encounter) %>
+
+            <% if encounter.bye? %>
+              <article class="competition-tree__match competition-tree__match--bye" style="<%= match_style(encounter) %>">
+                <div class="competition-tree__match-header">
+                  <span class="competition-tree__bye-label">Bye</span>
+                </div>
+                <ol class="competition-tree__fighters">
+                  <li class="competition-tree__fighter competition-tree__fighter--winner">
+                    <span class="competition-tree__fighter-name"><%= team_name(encounter, encounter.bye_slot) %></span>
+                  </li>
+                </ol>
+              </article>
+            <% else %>
+              <article class="competition-tree__match" style="<%= match_style(encounter) %>">
+                <div class="competition-tree__match-header">
+                  <%= link_to "Encounter #{display_number(encounter)}", encounter_path(encounter),
+                        data: {turbo_frame: panel_dom_id} %>
+                  <% if (line = score_line(encounter)) %>
+                    <span class="competition-tree__admin-summary"><%= line %></span>
+                  <% end %>
+                </div>
+                <ol class="competition-tree__fighters">
+                  <% [1, 2].each do |slot| %>
+                    <li class="competition-tree__fighter <%= "competition-tree__fighter--winner" if team_winner?(encounter, slot) %>">
+                      <% if (seed = seed_label(encounter, slot)) && encounter.public_send(:"resolved_team_#{slot}").blank? %>
+                        <span class="competition-tree__pool-position"><%= seed %></span>
+                      <% end %>
+                      <span class="competition-tree__fighter-name"><%= team_name(encounter, slot) %></span>
+                    </li>
+                  <% end %>
+                </ol>
+              </article>
+            <% end %>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/components/individual_pool_unpooled_component.rb
+++ b/app/components/individual_pool_unpooled_component.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Lists a pooled individual category's late-registering participants
+# (pool_number nil) so an admin can add each to an existing pool or split it
+# into a new one — by dragging the row onto a pool card (the pool-membership
+# Stimulus controller) or via the per-row "Add to…" select. The root element
+# always renders (even with no unpooled members) so a Turbo Stream replace
+# always has a target after a member is added and drops off the list.
+#
+# Individual analog of TeamPoolUnpooledComponent.
+class IndividualPoolUnpooledComponent < ViewComponent::Base
+  include ActionView::RecordIdentifier
+
+  def initialize(category:)
+    @category = category
+  end
+
+  private attr_reader :category
+
+  private def participations
+    @participations ||= category.participations.no_pool.includes(:kenshi)
+      .sort_by { |participation| participation.full_name.to_s }
+  end
+
+  private def pool_numbers
+    @pool_numbers ||= category.pools.map(&:number).sort
+  end
+
+  # The select's "New pool" option targets a pool number no participant holds
+  # yet; PoolMembershipMove treats that as a freshly-created pool.
+  private def next_pool_number
+    (pool_numbers.max || 0) + 1
+  end
+
+  private def dom_id_for_unpooled
+    "individual_pool_unpooled_#{category.id}"
+  end
+
+  private def move_url(participation)
+    helpers.admin_individual_category_pool_membership_path(category, participation)
+  end
+end

--- a/app/components/individual_pool_unpooled_component/individual_pool_unpooled_component.html.erb
+++ b/app/components/individual_pool_unpooled_component/individual_pool_unpooled_component.html.erb
@@ -1,0 +1,37 @@
+<%# Always-visible staging area: lists late registrants, and is itself a drop
+    zone — dropping a pooled member here removes it from its pool (see
+    pool_membership_controller#dropUnpool). %>
+<%= tag.div id: dom_id_for_unpooled, class: "pool-unpooled",
+      data: {controller: "pool-membership",
+             action: "dragover->pool-membership#dragOver " \
+               "dragleave->pool-membership#dragLeave drop->pool-membership#dropUnpool"} do %>
+  <h3 class="pool-unpooled__title">Unpooled participants</h3>
+  <% if participations.any? %>
+    <ul class="pool-unpooled__list">
+      <% participations.each do |participation| %>
+        <li class="pool-unpooled__team" data-participation-id="<%= participation.id %>"
+            data-move-url="<%= move_url(participation) %>">
+          <span class="pool-unpooled__grip pool-match__grip" draggable="true"
+                title="Drag onto a pool" data-action="dragstart->pool-membership#dragStart">⠿</span>
+          <% if participation.kenshi %>
+            <%= link_to participation.full_name, helpers.admin_kenshi_path(participation.kenshi),
+                  class: "pool-unpooled__name" %>
+          <% else %>
+            <span class="pool-unpooled__name"><%= participation.full_name %></span>
+          <% end %>
+          <select class="pool-standings__move-select"
+                  aria-label="Add <%= participation.full_name %> to a pool"
+                  data-action="change->pool-membership#moveViaSelect">
+            <option value="">Add to…</option>
+            <% pool_numbers.each do |number| %>
+              <option value="<%= number %>">Pool <%= number %></option>
+            <% end %>
+            <option value="<%= next_pool_number %>">New pool (Pool <%= next_pool_number %>)</option>
+          </select>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="pool-unpooled__hint">Drag a participant here to remove them from their pool.</p>
+  <% end %>
+<% end %>

--- a/app/components/pool_component.html.erb
+++ b/app/components/pool_component.html.erb
@@ -3,9 +3,24 @@
     <%= helpers.turbo_stream_from category, :competition_tree %>
   <% end %>
 
-  <div class="pool-card">
-    <h3 class="pool-card__title">Pool <%= pool_number %> (total Dan: <%= pool&.total_dan %>)</h3>
+  <%= tag.div class: "pool-card", data: container_data do %>
+    <div class="pool-card__header">
+      <h3 class="pool-card__title">Pool <%= pool_number %> (total Dan: <%= pool&.total_dan %>)</h3>
+      <% if admin && participations.size >= 2 %>
+        <%= helpers.button_to regenerate_button_label,
+              helpers.regenerate_pool_fights_admin_individual_category_path(category),
+              method: :post,
+              params: {pool_number: pool_number},
+              class: "pool-card__reset",
+              form: {class: "pool-card__reset-form"},
+              data: regenerate_button_data %>
+      <% end %>
+    </div>
 
+    <%# Inline alert: the pool_fights / fight_points error flow re-renders THIS
+        card via Turbo Stream and surfaces its validation message here, so it must
+        stay in the card (a full-page load with an ambient flash shows it per card,
+        but those flows are all XHR). %>
     <% if helpers.flash[:alert].present? %>
       <p class="pool-card__alert" role="alert"><%= helpers.flash[:alert] %></p>
     <% end %>
@@ -25,15 +40,22 @@
           <th>Pts+</th>
           <th>Pts−</th>
           <th>Rank</th>
-          <% if admin %><th></th><% end %>
+          <% if admin %><th><span class="pool-standings__sr-only">Move</span></th><th></th><% end %>
         </tr>
       </thead>
       <tbody>
         <% standings_rows.each do |row| %>
           <% participation = row.participation # rubocop:disable Lint/UselessAssignment %>
           <% kenshi = participation.kenshi # rubocop:disable Lint/UselessAssignment %>
-          <tr>
+          <tr<% if admin %> data-participation-id="<%= participation.id %>"
+              data-move-url="<%= move_url(participation) %>"
+              data-from-pool="<%= pool_number %>"<% end %>>
             <td>
+              <% if admin %>
+                <span class="pool-standings__grip pool-match__grip" draggable="true"
+                      title="Drag to another pool"
+                      data-action="dragstart->pool-membership#dragStart">⠿</span>
+              <% end %>
               <% if kenshi %>
                 <%= helpers.link_to participation.full_name, helpers.admin_kenshi_path(kenshi) %>
               <% else %>
@@ -43,26 +65,11 @@
             <td><%= participation.grade %></td>
             <td><%= participation.club %></td>
             <td><%= kenshi&.age_at_cup %></td>
-            <td>
-              <% if admin %>
-                <%= helpers.best_in_place participation, :pool_number, as: :input,
-                      url: [:admin, participation],
-                      class: "best_in_place_short pool-standings__editable",
-                      place_holder: "—" %>
-              <% else %>
-                <%= participation.pool_number %>
-              <% end %>
-            </td>
-            <td>
-              <% if admin %>
-                <%= helpers.best_in_place participation, :pool_position, as: :input,
-                      url: [:admin, participation],
-                      class: "best_in_place_short pool-standings__editable",
-                      place_holder: "—" %>
-              <% else %>
-                <%= participation.pool_position %>
-              <% end %>
-            </td>
+            <%# pool_number / pool_position are read-only: the drag-and-drop move
+                tool (PoolMembershipMove) owns them and rebuilds the derived
+                fights/bracket. Inline editing here would bypass that. %>
+            <td><%= participation.pool_number %></td>
+            <td><%= participation.pool_position %></td>
             <td><%= row.wins %></td>
             <td><%= row.losses %></td>
             <td><%= row.hikiwake %></td>
@@ -82,6 +89,21 @@
               <% end %>
             </td>
             <% if admin %>
+              <td class="pool-standings__move">
+                <% others = other_pool_numbers # rubocop:disable Lint/UselessAssignment %>
+                <% if others.any? %>
+                  <select class="pool-standings__move-select"
+                          aria-label="Move <%= participation.full_name %> to another pool"
+                          data-action="change->pool-membership#moveViaSelect">
+                    <option value="">Move to…</option>
+                    <% others.each do |n| %>
+                      <option value="<%= n %>">Pool <%= n %></option>
+                    <% end %>
+                  </select>
+                <% end %>
+              </td>
+            <% end %>
+            <% if admin %>
               <td class="pool-standings__actions">
                 <%= helpers.link_to "Edit", helpers.edit_admin_participation_path(participation), data: {turbo_frame: "_top"} %>
               </td>
@@ -99,33 +121,23 @@
           <%= helpers.render "admin/pool_fights/match", category: category, fight: fight,
                 point_codes: point_codes, admin: admin, poster_names: category.pool_poster_names %>
         <% end %>
-        <% tiebreaker_fights.each do |fight| %>
+        <% kettei_sen_fights.each do |fight| %>
           <%= helpers.render "admin/pool_fights/match", category: category, fight: fight,
                 point_codes: point_codes, admin: admin, poster_names: category.pool_poster_names %>
         <% end %>
       </ol>
 
       <% if admin %>
-        <% tiebreaker_options = participations.filter_map { |p| [poster_name(p.kenshi), p.kenshi_id] if p.kenshi } %>
+        <% kettei_sen_options = participations.filter_map { |p| [poster_name(p.kenshi), p.kenshi_id] if p.kenshi } %>
         <%= helpers.form_with url: helpers.admin_individual_category_pool_fights_path(category),
               method: :post, class: "pool-add-tiebreaker" do |f| %>
           <%= f.hidden_field "pool_fight[pool_number]", value: pool_number %>
-          <%= f.select "pool_fight[fighter_1_id]", tiebreaker_options %>
+          <%= f.select "pool_fight[fighter_1_id]", kettei_sen_options %>
           <span>vs</span>
-          <%= f.select "pool_fight[fighter_2_id]", tiebreaker_options %>
-          <%= f.submit "Add tiebreaker", class: "pool-add-tiebreaker__submit" %>
+          <%= f.select "pool_fight[fighter_2_id]", kettei_sen_options %>
+          <%= f.submit "Add kettei-sen", class: "pool-add-tiebreaker__submit" %>
         <% end %>
       <% end %>
     <% end %>
-
-    <% if admin && participations.size >= 2 %>
-      <%= helpers.button_to regenerate_button_label,
-            helpers.regenerate_pool_fights_admin_individual_category_path(category),
-            method: :post,
-            params: {pool_number: pool_number},
-            class: "pool-card__reset",
-            form: {class: "pool-card__reset-form"},
-            data: regenerate_button_data %>
-    <% end %>
-  </div>
+  <% end %>
 <% end %>

--- a/app/components/pool_component.rb
+++ b/app/components/pool_component.rb
@@ -36,7 +36,7 @@ class PoolComponent < ViewComponent::Base
     pool_fights.reject(&:tiebreaker).sort_by(&:number)
   end
 
-  private def tiebreaker_fights
+  private def kettei_sen_fights
     pool_fights.select(&:tiebreaker).sort_by { |f| [f.created_at.to_f, f.id] }
   end
 
@@ -46,6 +46,27 @@ class PoolComponent < ViewComponent::Base
 
   private def dom_id_for_pool
     helpers.pool_dom_id(category, pool_number)
+  end
+
+  # Admin cards are drop targets for the pool-membership drag-and-drop: a
+  # participation row dragged from another card drops here to join this pool.
+  private def container_data
+    return {} unless admin
+
+    {
+      controller: "pool-membership",
+      pool_membership_pool_number_value: pool_number,
+      action: "dragover->pool-membership#dragOver " \
+        "dragleave->pool-membership#dragLeave drop->pool-membership#drop"
+    }
+  end
+
+  private def move_url(participation)
+    helpers.admin_individual_category_pool_membership_path(category, participation)
+  end
+
+  private def other_pool_numbers
+    category.pools.map(&:number).sort - [pool_number]
   end
 
   private def point_codes
@@ -59,6 +80,6 @@ class PoolComponent < ViewComponent::Base
   private def regenerate_button_data
     return {} if pool_fights.empty?
 
-    {confirm: "This deletes every fight and tiebreaker for pool #{pool_number} and recreates them. Continue?"}
+    {confirm: "This deletes every fight and kettei-sen for pool #{pool_number} and recreates them. Continue?"}
   end
 end

--- a/app/components/team_pool_component.rb
+++ b/app/components/team_pool_component.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class TeamPoolComponent < ViewComponent::Base
+  include ActionView::RecordIdentifier
+
+  def initialize(team_category:, pool_number:, admin: true)
+    @team_category = team_category
+    @pool_number = pool_number
+    @admin = admin
+  end
+
+  private attr_reader :team_category, :pool_number, :admin
+
+  private def encounters
+    @encounters ||= team_category.encounters_by_pool_number.fetch(pool_number, [])
+  end
+
+  private def dom_id_for_pool
+    "team_pool_#{team_category.id}_#{pool_number}"
+  end
+
+  # Admin cards are drop targets for the pool-membership drag-and-drop: a team
+  # row dragged from another card drops here to join this pool.
+  private def container_data
+    return {} unless admin
+
+    {
+      controller: "pool-membership",
+      pool_membership_pool_number_value: pool_number,
+      action: "dragover->pool-membership#dragOver " \
+        "dragleave->pool-membership#dragLeave drop->pool-membership#drop"
+    }
+  end
+end

--- a/app/components/team_pool_component/team_pool_component.html.erb
+++ b/app/components/team_pool_component/team_pool_component.html.erb
@@ -1,0 +1,28 @@
+<%= tag.div id: dom_id_for_pool, class: "pool-card", data: container_data do %>
+  <% if admin %><%= helpers.turbo_stream_from team_category, :team_pools %><% end %>
+  <h3 class="pool-card__title">Pool <%= pool_number %></h3>
+
+  <%= helpers.render "admin/team_categories/pool_standings",
+        team_category: team_category, pool_number: pool_number, admin: admin %>
+
+  <% if encounters.empty? %>
+    <p class="pool-card__empty">No pool encounters yet.</p>
+  <% elsif admin %>
+    <% encounters.each do |encounter| %>
+      <details class="pool-encounter"><%# herb:disable html-details-has-summary %>
+        <%= helpers.render "admin/encounters/summary", encounter: encounter %>
+        <%= helpers.render "admin/encounters/editor", encounter: encounter, auto_seed: true %>
+      </details>
+    <% end %>
+  <% else %>
+    <ul class="pool-encounters">
+      <% encounters.each do |encounter| %>
+        <li>
+          <%= helpers.link_to "#{encounter.team_1.name} vs #{encounter.team_2.name}",
+                helpers.admin_team_category_encounter_path(team_category, encounter) %>
+          <%= "→ #{encounter.winner.name}" if encounter.winner %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/components/team_pool_unpooled_component.rb
+++ b/app/components/team_pool_unpooled_component.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Lists a pooled category's late-registering teams (pool_number nil) so an admin
+# can add each to an existing pool or split it into a new one — by dragging the
+# row onto a pool card (the pool-membership Stimulus controller) or via the
+# per-row "Add to…" select. The root element always renders (even with no
+# unpooled teams) so a Turbo Stream replace always has a target after a team is
+# added and drops off the list.
+class TeamPoolUnpooledComponent < ViewComponent::Base
+  include ActionView::RecordIdentifier
+
+  def initialize(team_category:)
+    @team_category = team_category
+  end
+
+  private attr_reader :team_category
+
+  private def teams
+    @teams ||= team_category.teams.where(pool_number: nil).order(:name)
+  end
+
+  private def pool_numbers
+    @pool_numbers ||= team_category.team_pools.map(&:number)
+  end
+
+  # The select's "New pool" option targets a pool number no team holds yet;
+  # TeamPoolMove treats that as a freshly-created pool.
+  private def next_pool_number
+    (pool_numbers.max || 0) + 1
+  end
+
+  private def dom_id_for_unpooled
+    "team_pool_unpooled_#{team_category.id}"
+  end
+
+  private def move_url(team)
+    helpers.admin_team_category_pool_membership_path(team_category, team)
+  end
+end

--- a/app/components/team_pool_unpooled_component/team_pool_unpooled_component.html.erb
+++ b/app/components/team_pool_unpooled_component/team_pool_unpooled_component.html.erb
@@ -1,0 +1,30 @@
+<%# Always-visible staging area: lists late registrants, and is itself a drop
+    zone — dropping a pooled team here removes it from its pool (see
+    pool_membership_controller#dropUnpool). %>
+<%= tag.div id: dom_id_for_unpooled, class: "pool-unpooled",
+      data: {controller: "pool-membership",
+             action: "dragover->pool-membership#dragOver " \
+               "dragleave->pool-membership#dragLeave drop->pool-membership#dropUnpool"} do %>
+  <h3 class="pool-unpooled__title">Unpooled teams</h3>
+  <% if teams.any? %>
+    <ul class="pool-unpooled__list">
+      <% teams.each do |team| %>
+        <li class="pool-unpooled__team" data-team-id="<%= team.id %>" data-move-url="<%= move_url(team) %>">
+          <span class="pool-unpooled__grip pool-match__grip" draggable="true"
+                title="Drag onto a pool" data-action="dragstart->pool-membership#dragStart">⠿</span>
+          <%= link_to team.name, [:admin, team], class: "pool-unpooled__name" %>
+          <select class="pool-standings__move-select" aria-label="Add <%= team.name %> to a pool"
+                  data-action="change->pool-membership#moveViaSelect">
+            <option value="">Add to…</option>
+            <% pool_numbers.each do |number| %>
+              <option value="<%= number %>">Pool <%= number %></option>
+            <% end %>
+            <option value="<%= next_pool_number %>">New pool (Pool <%= next_pool_number %>)</option>
+          </select>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="pool-unpooled__hint">Drag a team here to remove it from its pool.</p>
+  <% end %>
+<% end %>

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -29,5 +29,31 @@ module Admin
         end
       end
     end
+
+    private def respond_with_encounter(encounter, notice: nil)
+      respond_to do |format|
+        format.html do
+          redirect_to admin_team_category_encounter_path(encounter.team_category, encounter),
+            notice: notice
+        end
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace(
+            helpers.dom_id(encounter),
+            EncounterComponent.new(encounter: encounter, admin: true, alert: flash[:alert]),
+            method: :morph
+          )
+        end
+      end
+    end
+
+    # Shared finders for the encounter-scoped controllers (daihyōsens, team
+    # fights, team-fight points), which are all nested under an encounter.
+    private def team_category
+      @team_category ||= TeamCategory.find(params.expect(:team_category_id))
+    end
+
+    private def encounter
+      @encounter ||= team_category.encounters.find(params.expect(:encounter_id))
+    end
   end
 end

--- a/app/controllers/admin/encounters/daihyosens_controller.rb
+++ b/app/controllers/admin/encounters/daihyosens_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Admin
+  module Encounters
+    # Edits the daihyōsen representatives. Each id is resolved THROUGH that team's
+    # roster (TeamFight enforces no such membership), so an off-team pick is
+    # rejected. Locked once the bout has points (changing a scored rep would
+    # orphan the result), mirroring EncounterLineup.
+    class DaihyosensController < Admin::BaseController
+      def update
+        return head :unprocessable_content if daihyosen.fight_points.exists?
+
+        daihyosen.update!(rep_params)
+        respond_with_encounter(encounter)
+      rescue ActiveRecord::RecordNotFound
+        head :unprocessable_content
+      end
+
+      private def rep_params
+        attrs = {}
+        attrs[:kenshi_1_id] = member_id(encounter.resolved_team_1, params[:kenshi_1_id]) if params.key?(:kenshi_1_id)
+        attrs[:kenshi_2_id] = member_id(encounter.resolved_team_2, params[:kenshi_2_id]) if params.key?(:kenshi_2_id)
+        attrs
+      end
+
+      # nil for a blank pick; raises RecordNotFound (-> 422) for an off-team id
+      # or an unresolved slot (no team yet), rather than 500ing on nil.kenshis.
+      private def member_id(team, raw)
+        return nil if raw.blank?
+        raise ActiveRecord::RecordNotFound unless team
+
+        team.kenshis.find(raw).id
+      end
+
+      private def daihyosen
+        @daihyosen ||= encounter.team_fights.find_by!(daihyosen: true)
+      end
+    end
+  end
+end

--- a/app/controllers/admin/encounters/lineup_seeds_controller.rb
+++ b/app/controllers/admin/encounters/lineup_seeds_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Admin
+  module Encounters
+    # Seeds a fresh encounter's unset sides with their suggested order when the
+    # admin opens it (POSTed once by the lineup Stimulus controller on connect),
+    # then morphs the panel so the populated, draggable bouts appear in place.
+    class LineupSeedsController < Admin::BaseController
+      before_action :set_team_category
+
+      def create
+        encounter = @team_category.encounters.find(params.expect(:encounter_id))
+        EncounterLineupSeeder.new(encounter).call
+        respond_with_encounter(encounter)
+      end
+
+      private def set_team_category
+        @team_category = TeamCategory.find(params.expect(:team_category_id))
+      end
+    end
+  end
+end

--- a/app/controllers/admin/encounters/lineups_controller.rb
+++ b/app/controllers/admin/encounters/lineups_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Admin
+  module Encounters
+    # Replaces one team's fighter order for an encounter. The lineup form sends
+    # one value per position in order, so the array index IS the position;
+    # unselected (forfeit) slots arrive as empty strings and map to nil, keeping
+    # a blank at its position rather than shifting later fighters up.
+    class LineupsController < Admin::BaseController
+      def update
+        team = team_category.teams.find(params.expect(:team_id))
+        EncounterLineup.new(encounter).assign(team, lineup_kenshi_ids)
+        respond_with_encounter(encounter, notice: t(".notice"))
+      rescue EncounterLineup::InvalidLineup => e
+        flash.now[:alert] = e.message
+        respond_with_encounter(encounter)
+      end
+
+      private def lineup_kenshi_ids
+        Array(params[:kenshi_ids]).map(&:presence)
+      end
+    end
+  end
+end

--- a/app/controllers/admin/encounters/team_swaps_controller.rb
+++ b/app/controllers/admin/encounters/team_swaps_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Admin
+  module Encounters
+    # Swaps a bracket-only round-1 slot's occupant with another round-1 team —
+    # the admin's draw-correction tool (see EncounterTeamSwap for the rules).
+    class TeamSwapsController < Admin::BaseController
+      def create
+        team = team_category.teams.find(params.expect(:team_id))
+        EncounterTeamSwap.new(encounter).swap(params.expect(:slot).to_i, team)
+        redirect_to admin_team_category_path(team_category), notice: t(".notice")
+      rescue EncounterTeamSwap::InvalidSwap => e
+        redirect_to admin_team_category_path(team_category), alert: e.message
+      end
+    end
+  end
+end

--- a/app/controllers/admin/encounters_controller.rb
+++ b/app/controllers/admin/encounters_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Admin
+  class EncountersController < BaseController
+    before_action :set_team_category
+
+    def index
+      @encounters = @team_category.encounters
+        .includes(:team_1, :team_2, :winner,
+          parent_encounter_1: :winner, parent_encounter_2: :winner)
+        .order(:id)
+    end
+
+    def show
+      @encounter = @team_category.encounters.find(params.expect(:id))
+    end
+
+    def new
+    end
+
+    def create
+      permitted = params.expect(encounter: [:team_1_id, :team_2_id])
+      encounter = @team_category.encounters.create!(permitted)
+      redirect_to admin_team_category_encounter_path(@team_category, encounter),
+        notice: t(".notice")
+    rescue ActiveRecord::RecordInvalid => e
+      redirect_to new_admin_team_category_encounter_path(@team_category),
+        alert: e.record.errors.full_messages.to_sentence
+    end
+
+    private def set_team_category
+      @team_category = TeamCategory.find(params.expect(:team_category_id))
+    end
+  end
+end

--- a/app/controllers/admin/individual_categories/pool_memberships_controller.rb
+++ b/app/controllers/admin/individual_categories/pool_memberships_controller.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module Admin
+  module IndividualCategories
+    # Moves a participation into another pool (drag-and-drop on the pool cards,
+    # or the accessible "Move to" select). The membership change lives in
+    # PoolMembershipMove. When the move would discard real work, the service
+    # returns :needs_confirmation and we answer 422 so the client can confirm
+    # and retry with force=true. Individual analog of
+    # Admin::TeamCategories::PoolMembershipsController.
+    class PoolMembershipsController < Admin::BaseController
+      def update
+        participation = individual_category.participations.find(params.expect(:id))
+        result = PoolMembershipMove.new(
+          participation: participation, to_pool_number: params[:to_pool_number], force: forced?
+        ).call
+
+        case result.status
+        when :needs_confirmation
+          render json: {message: result.message}, status: :unprocessable_content
+        when :noop
+          head :no_content
+        else
+          broadcast(result)
+          render turbo_stream: streams_for(result)
+        end
+      end
+
+      private def individual_category
+        @individual_category ||= IndividualCategory.find(params.expect(:individual_category_id))
+      end
+
+      private def forced?
+        ActiveModel::Type::Boolean.new.cast(params[:force])
+      end
+
+      private def broadcast(result)
+        Turbo::StreamsChannel.broadcast_stream_to(
+          [individual_category, :competition_tree], content: streams_for(result)
+        )
+      end
+
+      private def streams_for(result)
+        tags = if result.created_pool
+          # A brand-new pool: replace the whole container (re-rendering every
+          # card) rather than appending one. The acting admin is subscribed to
+          # the same stream we broadcast to, so an append would be applied twice
+          # on their own page; a container replace is idempotent. It also
+          # refreshes — or drops — the source pool card as a side effect.
+          [pools_container_stream, unpooled_panel_stream]
+        else
+          [destination_stream(result), source_stream(result), unpooled_panel_stream]
+        end
+        tags << bracket_tree_stream if result.bracket_cleared
+        helpers.safe_join(tags.compact)
+      end
+
+      private def destination_stream(result)
+        return if result.to_pool.nil?
+
+        pool_card_stream(result.to_pool)
+      end
+
+      private def source_stream(result)
+        return if result.from_pool.nil?
+
+        if result.emptied_pools.include?(result.from_pool)
+          helpers.turbo_stream.remove(pool_dom_id(result.from_pool))
+        else
+          pool_card_stream(result.from_pool)
+        end
+      end
+
+      private def pools_container_stream
+        helpers.turbo_stream.replace(
+          "individual_pools_#{individual_category.id}",
+          partial: "admin/individual_categories/pools",
+          locals: {category: individual_category}
+        )
+      end
+
+      private def pool_card_stream(pool_number)
+        helpers.turbo_stream.replace(
+          pool_dom_id(pool_number),
+          PoolComponent.new(category: individual_category, pool_number: pool_number, admin: true)
+        )
+      end
+
+      private def unpooled_panel_stream
+        helpers.turbo_stream.replace(
+          "individual_pool_unpooled_#{individual_category.id}",
+          IndividualPoolUnpooledComponent.new(category: individual_category)
+        )
+      end
+
+      private def bracket_tree_stream
+        helpers.turbo_stream.replace(
+          helpers.dom_id(individual_category, :competition_tree),
+          CompetitionTreeComponent.new(category: individual_category, admin: true)
+        )
+      end
+
+      private def pool_dom_id(pool_number)
+        helpers.pool_dom_id(individual_category, pool_number)
+      end
+    end
+  end
+end

--- a/app/controllers/admin/pool_fights_controller.rb
+++ b/app/controllers/admin/pool_fights_controller.rb
@@ -13,7 +13,7 @@ module Admin
       category = IndividualCategory.find(params.expect(:individual_category_id))
       permitted = params.expect(pool_fight: [:pool_number, :fighter_1_id, :fighter_2_id])
 
-      unless tiebreaker_fighters_valid?(category, permitted)
+      unless kettei_sen_fighters_valid?(category, permitted)
         flash.now[:alert] = t(".alert")
         respond_with_pool(category, permitted[:pool_number].to_i)
         return
@@ -75,7 +75,7 @@ module Admin
       respond_with_pool(category, pool_number, notice: "Pool fights regenerated.")
     end
 
-    private def tiebreaker_fighters_valid?(category, permitted)
+    private def kettei_sen_fighters_valid?(category, permitted)
       fighter_1_id = permitted[:fighter_1_id].to_i
       fighter_2_id = permitted[:fighter_2_id].to_i
       return false if fighter_1_id <= 0 || fighter_2_id <= 0

--- a/app/controllers/admin/team_categories/pool_memberships_controller.rb
+++ b/app/controllers/admin/team_categories/pool_memberships_controller.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module Admin
+  module TeamCategories
+    # Moves a team into another pool (drag-and-drop on the pool cards, or the
+    # accessible "Move to" select). A team's pool membership is the resource;
+    # the move itself lives in TeamPoolMove. When the move would discard real
+    # work, the service returns :needs_confirmation and we answer 422 so the
+    # client can confirm and retry with force=true.
+    class PoolMembershipsController < Admin::BaseController
+      def update
+        team = team_category.teams.find(params.expect(:id))
+        result = TeamPoolMove.new(team: team, to_pool_number: params[:to_pool_number], force: forced?).call
+
+        case result.status
+        when :needs_confirmation
+          render json: {message: result.message}, status: :unprocessable_content
+        when :noop
+          head :no_content
+        else
+          broadcast(result)
+          render turbo_stream: streams_for(result)
+        end
+      end
+
+      private def forced?
+        ActiveModel::Type::Boolean.new.cast(params[:force])
+      end
+
+      # Identical actions to the acting admin (immediate) and every other open
+      # session (broadcast) — built once so the two can never drift.
+      private def broadcast(result)
+        Turbo::StreamsChannel.broadcast_stream_to([team_category, :team_pools], content: streams_for(result))
+      end
+
+      private def streams_for(result)
+        tags = if result.created_pool
+          # A brand-new pool: replace the whole container (re-rendering every
+          # card) rather than appending one. The acting admin is subscribed to
+          # the same stream we broadcast to, so an append would be applied twice
+          # on their own page; a container replace is idempotent. It also
+          # refreshes — or drops — the source pool card as a side effect.
+          [pools_container_stream, unpooled_panel_stream]
+        else
+          # A real source pool is replaced (or removed when emptied); an unpooled
+          # source (a late registrant joining) has no card to update.
+          [destination_stream(result), source_stream(result), unpooled_panel_stream]
+        end
+        tags << bracket_tree_stream if result.bracket_cleared
+        helpers.safe_join(tags.compact)
+      end
+
+      # An existing pool's card is replaced in place. Un-pooling (no destination
+      # pool) touches no destination card — only the unpooled panel and source.
+      private def destination_stream(result)
+        return if result.to_pool.nil?
+
+        pool_card_stream(result.to_pool)
+      end
+
+      private def source_stream(result)
+        return if result.from_pool.nil?
+
+        if result.emptied_pools.include?(result.from_pool)
+          helpers.turbo_stream.remove(pool_dom_id(result.from_pool))
+        else
+          pool_card_stream(result.from_pool)
+        end
+      end
+
+      private def pools_container_stream
+        helpers.turbo_stream.replace(
+          "team_pools_#{team_category.id}",
+          partial: "admin/team_categories/pools",
+          locals: {team_category: team_category}
+        )
+      end
+
+      private def pool_card_stream(pool_number)
+        helpers.turbo_stream.replace(
+          pool_dom_id(pool_number),
+          partial: "admin/team_categories/pool_card",
+          locals: {team_category: team_category, pool_number: pool_number}
+        )
+      end
+
+      private def unpooled_panel_stream
+        helpers.turbo_stream.replace(
+          "team_pool_unpooled_#{team_category.id}",
+          partial: "admin/team_categories/pool_unpooled",
+          locals: {team_category: team_category}
+        )
+      end
+
+      private def bracket_tree_stream
+        helpers.turbo_stream.replace(
+          helpers.dom_id(team_category, :encounter_tree),
+          partial: "team_bracket_trees/team_bracket_tree",
+          locals: {team_category: team_category}
+        )
+      end
+
+      private def pool_dom_id(pool_number)
+        "team_pool_#{team_category.id}_#{pool_number}"
+      end
+    end
+  end
+end

--- a/app/controllers/admin/team_fight_points_controller.rb
+++ b/app/controllers/admin/team_fight_points_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Admin
+  class TeamFightPointsController < BaseController
+    rescue_from ArgumentError, with: :render_unprocessable
+    rescue_from ActiveRecord::RecordInvalid, with: :flash_validation_error
+
+    def create
+      team_fight.with_lock { team_fight.fight_points.create!(point_params) }
+      respond_with_encounter(encounter)
+    end
+
+    def destroy
+      point = team_fight.fight_points.find(params.expect(:id))
+      point.destroy!
+      respond_with_encounter(encounter)
+    end
+
+    private def team_fight
+      @team_fight ||= encounter.team_fights.find(params.expect(:team_fight_id))
+    end
+
+    private def point_params
+      params.expect(team_fight_point: [:fighter_side, :kind])
+    end
+
+    private def flash_validation_error(exception)
+      flash.now[:alert] = exception.record.errors.full_messages.to_sentence
+      respond_with_encounter(encounter)
+    end
+
+    private def render_unprocessable
+      head :unprocessable_content
+    end
+  end
+end

--- a/app/controllers/admin/team_fights_controller.rb
+++ b/app/controllers/admin/team_fights_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Admin
+  # Toggles a regular bout's hikiwake (draw) flag. Eligibility is enforced on the
+  # server (TeamFight#hikiwake_eligible?) — the model has no draw validation, so
+  # a raw PATCH could otherwise mark a scored/forfeit/decided/unconfirmed bout.
+  class TeamFightsController < BaseController
+    def update
+      return head :unprocessable_content unless team_fight.hikiwake_eligible?
+
+      team_fight.update!(draw: ActiveModel::Type::Boolean.new.cast(draw_param))
+      respond_with_encounter(encounter)
+    end
+
+    private def draw_param
+      params.expect(team_fight: [:draw])[:draw]
+    end
+
+    private def team_fight
+      @team_fight ||= encounter.team_fights.find(params.expect(:id))
+    end
+  end
+end

--- a/app/helpers/encounters_helper.rb
+++ b/app/helpers/encounters_helper.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module EncountersHelper
+  # DOM id of the hidden, per-team lineup form that the in-table fighter
+  # dropdowns associate with via their `form=` attribute. Scoped to the
+  # encounter so the same team appearing in several pool encounters on
+  # one page never collides.
+  def lineup_form_id(encounter, team)
+    "lineup_#{dom_id(encounter)}_team_#{team.id}"
+  end
+
+  # DOM id of the hidden daihyōsen form the rep dropdowns associate with.
+  def daihyosen_form_id(encounter)
+    "daihyosen_#{dom_id(encounter)}"
+  end
+
+  # Score + outcome for an encounter's <summary>, without the team names — those
+  # head each column in the summary itself. Computes the EncounterResult once,
+  # and checks complete? before winner because EncounterResult#winner returns
+  # the leading team even mid-scoring.
+  def encounter_summary_status(encounter)
+    result = encounter.result
+    state =
+      if !result.complete?
+        " — not yet scored"
+      elsif result.winner
+        " → #{result.winner.name}"
+      else
+        " — hikiwake"
+      end
+    "wins #{result.team_1_wins}–#{result.team_2_wins}, " \
+      "ippons #{result.team_1_ippons}–#{result.team_2_ippons}#{state}"
+  end
+end

--- a/app/javascript/admin.js
+++ b/app/javascript/admin.js
@@ -1,6 +1,14 @@
 import '@hotwired/turbo-rails';
 import { Application } from '@hotwired/stimulus';
 import FightWinnerController from './controllers/fight_winner_controller';
+import LineupController from './controllers/lineup_controller';
+import EncounterPanelController from './controllers/encounter_panel_controller';
+import PoolMembershipController from './controllers/pool_membership_controller';
+import StreamLinkController from './controllers/stream_link_controller';
 
 const application = Application.start();
 application.register('fight-winner', FightWinnerController);
+application.register('lineup', LineupController);
+application.register('encounter-panel', EncounterPanelController);
+application.register('pool-membership', PoolMembershipController);
+application.register('stream-link', StreamLinkController);

--- a/app/javascript/controllers/encounter_panel_controller.js
+++ b/app/javascript/controllers/encounter_panel_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from '@hotwired/stimulus';
+
+// Controls the encounter editor panel below the bracket tree. This controller
+// rides on the Close button, which only exists once an encounter has loaded
+// into the panel — so connect() fires exactly when a tree card opens one.
+export default class extends Controller {
+  // Bring the freshly-loaded editor into view: a tree card sits well above the
+  // panel, so clicking one would otherwise leave the editor off-screen below.
+  // Turbo's frame `autoscroll` proved unreliable here, so scroll explicitly.
+  connect() {
+    const frame = this.element.closest('turbo-frame');
+    if (frame) frame.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  // Emptying the enclosing turbo-frame hides the editor without a server
+  // round-trip. The src attribute must also be cleared: if it survived, Turbo
+  // could treat a later click on the same encounter as a no-op navigation and
+  // leave the panel empty.
+  close() {
+    const frame = this.element.closest('turbo-frame');
+    if (!frame) return;
+    frame.removeAttribute('src');
+    frame.innerHTML = '';
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,9 +10,13 @@ import FlashController
 import NavigationController from './navigation_controller';
 import KenshiFormController from './kenshi_form_controller';
 import Select2SingleTagController from './select2_single_tag_controller';
+import LineupController from './lineup_controller';
+import PoolMembershipController from './pool_membership_controller';
 
 application.register('navigation-dropdown', NavigationDropdownController);
 application.register('navigation', NavigationController);
 application.register('flash', FlashController);
 application.register('kenshi-form', KenshiFormController);
 application.register('select2-single-tag', Select2SingleTagController);
+application.register('lineup', LineupController);
+application.register('pool-membership', PoolMembershipController);

--- a/app/javascript/controllers/lineup_controller.js
+++ b/app/javascript/controllers/lineup_controller.js
@@ -1,0 +1,147 @@
+import { Controller } from '@hotwired/stimulus';
+import { Turbo } from '@hotwired/turbo-rails';
+
+// Auto-saves a team's lineup when a fighter dropdown in the match table
+// changes. We POST with fetch and render the returned Turbo Stream ourselves
+// — the same approach as fight_winner_controller — rather than submitting the
+// form. A real form submission on the Active Admin page can fall back to a full
+// navigation, which reloads the page and scrolls to the top; a fetch +
+// renderStreamMessage only morphs the panel in place, so scroll is preserved.
+//
+// FormData(form) includes the <select>s that the table associates with this
+// form via their `form=` attribute, plus the hidden team_id and CSRF token.
+export default class extends Controller {
+  static values = { seedUrl: String };
+
+  // A freshly-opened editor with an unset side carries a seed URL: POST once to
+  // lay down the suggested order (persisted but unconfirmed) so the fighters
+  // become real and draggable. The response morphs the panel without the seed
+  // URL, so a reconnect after the morph won't fire again; clearing the value is
+  // a belt-and-braces guard against re-entrancy before the morph lands.
+  //
+  // In the pool view every encounter editor lives inside a collapsed <details>,
+  // whose content still connects its Stimulus controllers while hidden. Seeding
+  // on connect would auto-POST a seed for every bout panel just by opening the
+  // pool page. So when we're inside a <details>, defer the seed until it's
+  // actually opened; a standalone editor (no <details>) seeds immediately.
+  connect() {
+    if (!this.hasSeedUrlValue || !this.seedUrlValue) return;
+
+    const details = this.element.closest('details');
+    if (!details || details.open) {
+      this.seed();
+      return;
+    }
+    this.onToggle = () => { if (details.open) this.seed(); };
+    details.addEventListener('toggle', this.onToggle);
+  }
+
+  disconnect() {
+    if (!this.onToggle) return;
+    this.element.closest('details')?.removeEventListener('toggle', this.onToggle);
+    this.onToggle = null;
+  }
+
+  async seed() {
+    const url = this.seedUrlValue;
+    if (!url) return;
+    this.seedUrlValue = '';
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          Accept: 'text/vnd.turbo-stream.html',
+          'X-CSRF-Token': csrfToken || '',
+        },
+      });
+      if (!response.ok) {
+        console.error('lineup seed failed:', response.status, await response.text());
+        return;
+      }
+      Turbo.renderStreamMessage(await response.text());
+    } catch (error) {
+      console.error('lineup seed error:', error);
+    }
+  }
+
+  async submit(event) {
+    const { form } = event.target;
+    if (!form) return;
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+    try {
+      const response = await fetch(form.action, {
+        method: (form.method || 'post').toUpperCase(),
+        headers: {
+          Accept: 'text/vnd.turbo-stream.html',
+          'X-CSRF-Token': csrfToken || '',
+        },
+        body: new FormData(form),
+      });
+
+      if (!response.ok) {
+        console.error('lineup submit failed:', response.status, await response.text());
+        return;
+      }
+      Turbo.renderStreamMessage(await response.text());
+    } catch (error) {
+      console.error('lineup submit error:', error);
+    }
+  }
+
+  // --- Drag-to-reorder (swap) ----------------------------------------------
+  // Each fighter card has a drag handle. Dropping one fighter onto another card
+  // IN THE SAME TEAM COLUMN swaps just those two picks — swap, not insert: only
+  // the two slots change, everyone else stays put. We exchange the two <select>
+  // values and fire one change; both selects share the team's form, so submit()
+  // posts the whole reordered lineup in a single request.
+  dragStart(event) {
+    this.source = event.target.closest('[data-reorder-form]');
+    const { dataTransfer } = event;
+    dataTransfer.effectAllowed = 'move';
+    dataTransfer.setData('text/plain', ''); // Firefox needs a payload to drag
+  }
+
+  dragEnd() {
+    this.source = null;
+    this.element
+      .querySelectorAll('.pool-match__row--drop')
+      .forEach((row) => row.classList.remove('pool-match__row--drop'));
+  }
+
+  dragOver(event) {
+    if (!this.canDrop(event.currentTarget)) return;
+    event.preventDefault(); // a preventDefault'd dragover is what permits the drop
+    event.currentTarget.classList.add('pool-match__row--drop');
+  }
+
+  dragLeave(event) {
+    event.currentTarget.classList.remove('pool-match__row--drop');
+  }
+
+  drop(event) {
+    const target = event.currentTarget;
+    target.classList.remove('pool-match__row--drop');
+    if (!this.canDrop(target)) return;
+    event.preventDefault();
+
+    const from = this.source.querySelector('select');
+    const to = target.querySelector('select');
+    this.source = null;
+    if (!from || !to) return;
+
+    [from.value, to.value] = [to.value, from.value];
+    from.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+
+  // A drop is valid onto another card of the same team column. Scored bouts are
+  // allowed too — reordering one resets it server-side (its points are cleared).
+  canDrop(target) {
+    return (
+      this.source
+      && target !== this.source
+      && target.dataset.reorderForm === this.source.dataset.reorderForm
+    );
+  }
+}

--- a/app/javascript/controllers/pool_membership_controller.js
+++ b/app/javascript/controllers/pool_membership_controller.js
@@ -1,0 +1,107 @@
+import { Controller } from '@hotwired/stimulus';
+import { Turbo } from '@hotwired/turbo-rails';
+
+// Moves a team into another pool. Each pool card is its own controller
+// instance; a team row is dragged from its source card and dropped on a
+// destination card, so the dragged team's identity travels through the native
+// dataTransfer payload (cross-instance) rather than instance state. The
+// per-row "Move to" <select> is an accessible, mouse-free path to the same
+// move() call.
+//
+// The server owns the confirm decision: a destructive move (recorded results
+// or an existing bracket) answers 422 with a message; we confirm and retry
+// with force=true. On success we render the returned Turbo Stream, which
+// replaces the affected pool cards (or removes an emptied one).
+export default class extends Controller {
+  static values = { poolNumber: Number };
+
+  dragStart(event) {
+    const row = event.target.closest('[data-move-url]');
+    if (!row) return;
+    const { dataTransfer } = event;
+    dataTransfer.effectAllowed = 'move';
+    dataTransfer.setData(
+      'application/json',
+      JSON.stringify({ url: row.dataset.moveUrl, fromPool: Number(row.dataset.fromPool) }),
+    );
+  }
+
+  dragOver(event) {
+    event.preventDefault(); // a preventDefault'd dragover is what permits the drop
+    const { dataTransfer } = event;
+    dataTransfer.dropEffect = 'move';
+    this.element.classList.add('pool-card--drop');
+  }
+
+  dragLeave(event) {
+    // Ignore bubbling from children: only clear when the pointer truly leaves the card.
+    if (!this.element.contains(event.relatedTarget)) this.element.classList.remove('pool-card--drop');
+  }
+
+  drop(event) {
+    event.preventDefault();
+    this.element.classList.remove('pool-card--drop');
+    const payload = this.readPayload(event);
+    if (!payload) return;
+    if (payload.fromPool === this.poolNumberValue) return; // dropped back on its own pool
+    this.move(payload.url, this.poolNumberValue);
+  }
+
+  // Dropping a pooled team on the unpooled panel removes it from its pool (the
+  // server treats a blank destination as un-pool). A team already unpooled has
+  // no source pool, so it is a no-op.
+  dropUnpool(event) {
+    event.preventDefault();
+    this.element.classList.remove('pool-card--drop');
+    const payload = this.readPayload(event);
+    if (!payload || payload.fromPool == null) return;
+    this.move(payload.url, '');
+  }
+
+  // Accessible fallback: choosing a pool in a row's "Move to" select.
+  moveViaSelect(event) {
+    const select = event.target;
+    const toPool = Number(select.value);
+    if (!toPool) return;
+    const row = select.closest('[data-move-url]');
+    this.move(row.dataset.moveUrl, toPool);
+  }
+
+  readPayload(event) {
+    try {
+      return JSON.parse(event.dataTransfer.getData('application/json'));
+    } catch {
+      return null;
+    }
+  }
+
+  async move(url, toPool, force = false) {
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+    const body = new URLSearchParams({ to_pool_number: toPool });
+    if (force) body.set('force', 'true');
+    try {
+      const response = await fetch(url, {
+        method: 'PATCH',
+        headers: {
+          Accept: 'text/vnd.turbo-stream.html',
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'X-CSRF-Token': csrfToken || '',
+        },
+        body,
+      });
+      if (response.status === 422) {
+        const { message } = await response.json();
+        if (window.confirm(message)) this.move(url, toPool, true);
+        return;
+      }
+      if (response.status === 204) return; // no-op (same pool)
+      if (!response.ok) {
+        console.error('pool move failed:', response.status, await response.text());
+        return;
+      }
+      Turbo.renderStreamMessage(await response.text());
+    } catch (error) {
+      console.error('pool move error:', error);
+    }
+  }
+}

--- a/app/javascript/controllers/stream_link_controller.js
+++ b/app/javascript/controllers/stream_link_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from '@hotwired/stimulus';
+import { Turbo } from '@hotwired/turbo-rails';
+
+// Submits an admin action link via fetch and renders the returned Turbo Stream
+// in place. ActiveAdmin's jquery_ujs turns a `data-method` link into a full-page
+// form submit, which reloads and scrolls back to the top; intercepting the click
+// and POSTing ourselves keeps the admin where they are. Same approach as
+// lineup_controller / fight_winner_controller.
+//
+// The link is a plain <a> (no data-method) so neither jquery_ujs nor Turbo Drive
+// navigates on click; preventDefault stops Turbo Drive's own GET visit.
+export default class extends Controller {
+  static values = { confirm: String };
+
+  async submit(event) {
+    event.preventDefault();
+    if (this.confirmValue && !window.confirm(this.confirmValue)) return;
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+    try {
+      const response = await fetch(this.element.href, {
+        method: 'POST',
+        headers: {
+          Accept: 'text/vnd.turbo-stream.html',
+          'X-CSRF-Token': csrfToken || '',
+        },
+      });
+      if (!response.ok) {
+        console.error('stream-link failed:', response.status, await response.text());
+        return;
+      }
+      Turbo.renderStreamMessage(await response.text());
+    } catch (error) {
+      console.error('stream-link error:', error);
+    }
+  }
+}

--- a/app/models/concerns/acts_as_category.rb
+++ b/app/models/concerns/acts_as_category.rb
@@ -16,6 +16,9 @@ module ActsAsCategory
 
     translate :description
 
+    # NOT memoized: regeneration paths (PoolMembershipMove -> PoolFightGenerator)
+    # reuse one category instance and re-read this after mutating pool
+    # membership, so a cached snapshot would regenerate from stale membership.
     def pools
       pools = []
       if pool_size.to_i > 1

--- a/app/models/concerns/bracket_layout.rb
+++ b/app/models/concerns/bracket_layout.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+# Shared SVG bracket layout: card positions, canvas size, and connector paths for
+# a single-elimination tree, plus the visibility rules that hide forecasted/pass-
+# through nodes. Pure geometry — depends only on each node's round/position/bye?
+# and the parent links. Includers must define:
+#   bracket_nodes               -> Array of nodes (parents preloaded)
+#   node_parents(node)          -> [parent_or_nil, parent_or_nil]
+#   node_has_own_identity?(node)-> Boolean (renders even with no resolved child)
+module BracketLayout
+  extend ActiveSupport::Concern
+
+  CARD_WIDTH = 224
+  CARD_HEIGHT = 80
+  BYE_CARD_HEIGHT = 40
+  ROUND_GAP = 48
+  MATCH_GAP = 8
+  PADDING = 8
+
+  def rounds
+    @rounds ||= bracket_nodes.group_by(&:round)
+  end
+
+  def canvas_width
+    return 0 if rounds.empty?
+
+    BracketLayout::PADDING * 2 + rounds.keys.max * BracketLayout::CARD_WIDTH +
+      (rounds.keys.max - 1) * BracketLayout::ROUND_GAP
+  end
+
+  def canvas_height
+    return 0 if rounds.empty?
+
+    BracketLayout::PADDING * 2 + first_round_slots * (BracketLayout::CARD_HEIGHT + BracketLayout::MATCH_GAP) -
+      BracketLayout::MATCH_GAP
+  end
+
+  def first_round_slots
+    [rounds.fetch(1, []).size, 1].max
+  end
+
+  def match_style(node)
+    "left: #{match_left(node)}px; top: #{match_top(node)}px;"
+  end
+
+  def match_left(node)
+    BracketLayout::PADDING + (node.round - 1) * (BracketLayout::CARD_WIDTH + BracketLayout::ROUND_GAP)
+  end
+
+  def match_top(node)
+    height = node.bye? ? BracketLayout::BYE_CARD_HEIGHT : BracketLayout::CARD_HEIGHT
+    BracketLayout::PADDING + (node_center_y(node) - height / 2.0).round
+  end
+
+  def node_center_y(node)
+    slot_height = BracketLayout::CARD_HEIGHT + BracketLayout::MATCH_GAP
+    span = 2**(node.round - 1)
+    first_slot = (node.position - 1) * span
+
+    slot_height * (first_slot + (span / 2.0)) - BracketLayout::MATCH_GAP / 2.0
+  end
+
+  def connector_paths
+    rounds.values.flatten.filter_map do |node|
+      next unless render_node?(node)
+
+      parent_paths(node)
+    end.flatten
+  end
+
+  def render_node?(node)
+    rendered_node_ids.fetch(node.id) do
+      rendered_node_ids[node.id] = node_has_own_identity?(node) || render_forecasted_node?(node)
+    end
+  end
+
+  private def parent_paths(node)
+    connector_parents(node).map { |parent| connector_path(parent, node) }
+  end
+
+  private def connector_parents(node)
+    node_parents(node).compact.flat_map { |parent| visible_connector_parent(parent) }
+  end
+
+  private def visible_connector_parent(node)
+    return [node] if render_node?(node)
+    return connector_parents(node) if hidden_pass_through_node?(node)
+
+    []
+  end
+
+  private def connector_path(parent_node, node)
+    start_x = match_left(parent_node) + BracketLayout::CARD_WIDTH
+    start_y = BracketLayout::PADDING + node_center_y(parent_node).round
+    end_x = match_left(node)
+    end_y = BracketLayout::PADDING + node_center_y(node).round
+    elbow_x = start_x + (end_x - start_x) / 2
+
+    "M #{start_x} #{start_y} H #{elbow_x} V #{end_y} H #{end_x}"
+  end
+
+  private def rendered_node_ids
+    @rendered_node_ids ||= {}
+  end
+
+  private def render_forecasted_node?(node)
+    parents = node_parents(node).compact
+    parents.any? &&
+      parents.any? { |parent| render_node?(parent) } &&
+      !hidden_pass_through_node?(node)
+  end
+
+  private def hidden_pass_through_node?(node)
+    pass_through_node?(node) && child_nodes.fetch(node.id, []).any?
+  end
+
+  private def pass_through_node?(node)
+    parents = node_parents(node).compact
+    return false unless parents.size > 1
+
+    parents.one? { |parent| render_node?(parent) } &&
+      parents.any? { |parent| !render_node?(parent) }
+  end
+
+  private def child_nodes
+    @child_nodes ||= rounds.values.flatten.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |node, children|
+      node_parents(node).compact.each { |parent| children[parent.id] << node }
+    end
+  end
+end

--- a/app/models/concerns/scorable.rb
+++ b/app/models/concerns/scorable.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Shared point-scoring slice for records that are scored by FightPoints
+# (Fight, TeamFight). Includers implement four hooks:
+#   scoring_fighter(slot)  -> the fighter object on side 1/2 (id is read off it)
+#   forfeit                -> the fighter that wins by default, or nil
+#   tie_outcome(s1, s2)    -> {winner_id:, draw:} when both sides have equal points
+#   refresh_after_points   -> refresh downstream state when the outcome is unchanged
+module Scorable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :fight_points, -> { order(:position) }, as: :scorable, dependent: :destroy
+  end
+
+  def points_for(slot)
+    side = (slot == 1) ? "fighter_1" : "fighter_2"
+    fight_points.select { |point| point.fighter_side == side }
+  end
+
+  def first_scoring_point
+    fight_points.reject { |point| point.kind == "hansoku" }.min_by(&:position)
+  end
+
+  # Derives the outcome from points: a forfeit short-circuits to the present
+  # side; otherwise the side with more non-hansoku points wins; an equal score
+  # defers to the includer's tie_outcome. Returns true when the persisted
+  # outcome actually changed, false when it was already up to date.
+  def recompute_outcome_from_points!
+    outcome =
+      if (winner_by_default = forfeit)
+        {winner_id: winner_by_default.id, draw: false}
+      else
+        scored_1 = scoring_points_count(1)
+        scored_2 = scoring_points_count(2)
+        if scored_1 > scored_2
+          {winner_id: scoring_fighter(1)&.id, draw: false}
+        elsif scored_2 > scored_1
+          {winner_id: scoring_fighter(2)&.id, draw: false}
+        else
+          tie_outcome(scored_1, scored_2)
+        end
+      end
+
+    return false if winner_id == outcome[:winner_id] && draw == outcome[:draw]
+
+    update!(outcome)
+    true
+  end
+
+  # Outcome recomputation reads straight from the DB: it runs in write paths
+  # (point create/destroy, slot invalidation) where a cached fight_points set may
+  # be stale, so accuracy beats reusing a loaded association here. Read-side
+  # callers that count points for display use the in-memory points_for instead.
+  private def scoring_points_count(slot)
+    side = (slot == 1) ? "fighter_1" : "fighter_2"
+    fight_points.where(fighter_side: side).where.not(kind: "hansoku").count
+  end
+end

--- a/app/models/encounter.rb
+++ b/app/models/encounter.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+class Encounter < ApplicationRecord
+  belongs_to :team_category
+  belongs_to :team_1, class_name: "Team", optional: true
+  belongs_to :team_2, class_name: "Team", optional: true
+  belongs_to :parent_encounter_1, class_name: "Encounter", optional: true
+  belongs_to :parent_encounter_2, class_name: "Encounter", optional: true
+  belongs_to :winner, class_name: "Team", optional: true
+  has_many :team_fights, -> { order(:position) }, dependent: :destroy
+
+  validate :teams_differ
+  validate :teams_in_category
+  validates :team_1, :team_2, presence: true, if: -> { pool_number.present? }
+
+  scope :bracket_order, -> { order(:round, :position) }
+
+  after_update :propagate_winner_to_children, if: :saved_change_to_winner_id?
+  after_update :cascade_winner_clear_to_descendants, if: :saved_change_to_winner_id?
+  after_update :propagate_bye_to_children, if: :bye_occupant_changed?
+  # Winner changes AND slot-occupant changes (admin swaps, bye re-seeding)
+  # redraw the tree; pool encounters never do.
+  after_update_commit :broadcast_bracket_tree, if: -> {
+    pool_number.blank? &&
+      (saved_change_to_winner_id? || saved_change_to_team_1_id? || saved_change_to_team_2_id?)
+  }
+
+  delegate :team_size, to: :team_category
+
+  PARENT_ASSOCIATIONS = [:parent_encounter_1, :parent_encounter_2].freeze
+
+  def self.preload_parents(encounters)
+    by_id = encounters.index_by(&:id)
+    encounters.each do |encounter|
+      PARENT_ASSOCIATIONS.each do |name|
+        association = encounter.association(name)
+        association.target = by_id[encounter.public_send(:"#{name}_id")]
+        association.loaded!
+      end
+    end
+  end
+
+  def resolved_team_1
+    team_1 || parent_encounter_1&.winner_or_bye
+  end
+
+  def resolved_team_2
+    team_2 || parent_encounter_2&.winner_or_bye
+  end
+
+  def winner_or_bye
+    winner.presence || bye_team
+  end
+
+  def team_display_name(slot)
+    public_send(:"resolved_team_#{slot}")&.name || "To be decided"
+  end
+
+  def teams
+    [resolved_team_1, resolved_team_2].compact
+  end
+
+  def participating_teams
+    [team_1, team_2, resolved_team_1, resolved_team_2, winner, bye_team].compact.uniq
+  end
+
+  def bye?
+    bye_slot.present?
+  end
+
+  def bye_slot
+    return 1 if slot_present?(1) && !slot_present?(2) && parent_encounter_2.blank?
+    return 2 if slot_present?(2) && !slot_present?(1) && parent_encounter_1.blank?
+
+    nil
+  end
+
+  def bye_team
+    return unless bye_slot
+
+    public_send(:"resolved_team_#{bye_slot}")
+  end
+
+  def result
+    EncounterResult.new(self)
+  end
+
+  # No real work recorded yet: no winner, neither lineup confirmed, and no
+  # scored bouts. Used to decide whether destroying/reseating this encounter
+  # (a draw-correction swap, or moving a team between pools) is safe without
+  # explicit confirmation.
+  def pristine?
+    winner_id.nil? && !lineup_1_set? && !lineup_2_set? &&
+      # any? (not exists?) so a preloaded team_fights: :fight_points association is
+      # read in memory instead of firing one EXISTS query per bout.
+      team_fights.none? { |fight| fight.fight_points.any? }
+  end
+
+  # Persist the derived winning team; no-op when already current. Called
+  # post-commit (from TeamFight), so its own write never lands mid-transaction.
+  #
+  # Wrapped in with_lock: under live multi-tablet scoring two bouts of the same
+  # encounter commit concurrently and each fires this derive+write. Without a row
+  # lock both read their own snapshot and the later commit can persist a winner
+  # derived from a stale read of the other bout. The lock serializes the
+  # read-derive-write so the second recompute sees the first's committed outcome.
+  def recompute_winner!
+    with_lock do
+      # Drop any loaded team_fights so the result reads the just-written bout
+      # outcomes from the DB. A scored bout updates its own row, but the encounter
+      # instance reaching this write path may carry a stale cached collection (the
+      # same DB-over-cache rule Scorable applies to point recomputation).
+      team_fights.reset
+      res = result
+      derived = res.winner
+      update!(winner: derived) unless winner_id == derived&.id
+
+      if pool_number.present?
+        # Standings count only complete encounters, so re-rank the pool only when
+        # this encounter is complete now or just stopped being complete (e.g. a
+        # point was deleted). Scoring an early bout that leaves it incomplete is
+        # the common case and needs no re-rank.
+        now_complete = res.complete?
+        recompute_pool_standings! if now_complete || completed?
+        update_column(:completed, now_complete) if completed? != now_complete # rubocop:disable Rails/SkipsModelValidations
+      else
+        DaihyosenProposal.new(self).ensure!
+      end
+    end
+  end
+
+  # The single path for setting a bracket slot's team. First fill (nil -> team)
+  # just writes the column. Re-resolution (a different team, or nil) first
+  # invalidates the previous occupant's sub-state on that side, then writes the
+  # column and re-derives this encounter's winner. Both the winner-propagation
+  # callback and the builder's first-round re-resolve go through here, so stale
+  # state can never survive an advancement change.
+  def assign_team_to_slot(slot, team)
+    column = :"team_#{slot}_id"
+    return if public_send(column) == team&.id
+
+    previous_id = public_send(column)
+    update!(column => team&.id)
+
+    if previous_id.present? && team&.id != previous_id
+      invalidate_slot(slot)
+      recompute_winner!
+    end
+  end
+
+  def recompute_pool_standings!
+    pool_teams = team_category.teams.where(pool_number: pool_number).to_a
+    pool_encounters = team_category.encounters.where(pool_number: pool_number)
+      .includes(team_fights: :fight_points).to_a
+    TeamPoolStandings.persist_ranks!(teams: pool_teams, encounters: pool_encounters)
+  end
+
+  def children
+    self.class.where(team_category_id: team_category_id)
+      .where("parent_encounter_1_id = :id OR parent_encounter_2_id = :id", id: id)
+  end
+
+  # Wipe the previous occupant's data on side `slot`: kenshi, that side's
+  # fight_points (they are keyed by fighter_side, NOT by kenshi, so they would
+  # otherwise be counted for the new team), and the now-stale per-bout outcome.
+  private def invalidate_slot(slot)
+    side = (slot == 1) ? "fighter_1" : "fighter_2"
+    team_fights.each do |fight|
+      fight.fight_points.where(fighter_side: side).destroy_all
+      fight.update!("kenshi_#{slot}_id": nil)
+      fight.recompute_outcome_from_points!
+    end
+    update!("lineup_#{slot}_set": false)
+  end
+
+  private def broadcast_bracket_tree
+    broadcast_replace_later_to(
+      [team_category, :encounter_tree],
+      target: ActionView::RecordIdentifier.dom_id(team_category, :encounter_tree),
+      partial: "team_bracket_trees/team_bracket_tree",
+      locals: {team_category: team_category},
+      attributes: {method: :morph}
+    )
+  end
+
+  # Winner/bye changes propagate synchronously into child slots, each of which
+  # re-fires these callbacks on its own children — a write cascade bounded by
+  # tree height ONLY if the parent graph is acyclic. The bracket builder always
+  # produces a DAG, but nothing in the schema enforces it, so a data anomaly
+  # (a parent_encounter pointing at a descendant) would recurse forever. This
+  # guard tracks the encounters currently propagating on this thread and skips
+  # re-entering one already in the chain, breaking any cycle.
+  PROPAGATION_GUARD_KEY = :encounter_propagation_visited
+
+  private def with_propagation_guard
+    visited = (Thread.current[PROPAGATION_GUARD_KEY] ||= Set.new)
+    return if visited.include?(id)
+
+    visited.add(id)
+    begin
+      yield
+    ensure
+      visited.delete(id)
+    end
+  end
+
+  private def propagate_winner_to_children
+    with_propagation_guard do
+      children.find_each do |child|
+        slot = (child.parent_encounter_1_id == id) ? 1 : 2
+        child.assign_team_to_slot(slot, winner)
+      end
+    end
+  end
+
+  # A bye advances via bye_team, never winner_id, so the winner-propagation
+  # callback can't keep round 2 current when a bye's occupant changes (admin
+  # slot swap, or a pooled re-resolve). Mirror it for byes.
+  private def bye_occupant_changed?
+    (saved_change_to_team_1_id? || saved_change_to_team_2_id?) && winner_id.nil? && bye?
+  end
+
+  private def propagate_bye_to_children
+    with_propagation_guard do
+      children.find_each do |child|
+        slot = (child.parent_encounter_1_id == id) ? 1 : 2
+        child.assign_team_to_slot(slot, bye_team)
+      end
+    end
+  end
+
+  private def cascade_winner_clear_to_descendants
+    with_propagation_guard do
+      children.find_each do |child|
+        next if child.winner_id.nil?
+        next if [child.team_1_id, child.team_2_id].include?(child.winner_id)
+
+        child.update!(winner: nil)
+      end
+    end
+  end
+
+  private def slot_present?(slot)
+    public_send(:"team_#{slot}").present? ||
+      public_send(:"team_#{slot}_pool_number").present?
+  end
+
+  private def teams_differ
+    errors.add(:team_2, "must differ from team 1") if team_1_id && team_1_id == team_2_id
+  end
+
+  private def teams_in_category
+    [team_1, team_2].compact.each do |team|
+      next if team.team_category_id == team_category_id
+
+      errors.add(:base, "#{team.name} is not in this category")
+    end
+  end
+end

--- a/app/models/fight.rb
+++ b/app/models/fight.rb
@@ -2,6 +2,7 @@
 
 class Fight < ApplicationRecord
   include ActionView::RecordIdentifier
+  include Scorable
 
   belongs_to :individual_category
   belongs_to :winner, polymorphic: true, foreign_type: "fighter_type", optional: true
@@ -9,8 +10,6 @@ class Fight < ApplicationRecord
   belongs_to :parent_fight_2, class_name: "Fight", optional: true
   belongs_to :fighter_1, polymorphic: true, foreign_type: "fighter_type", optional: true
   belongs_to :fighter_2, polymorphic: true, foreign_type: "fighter_type", optional: true
-
-  has_many :fight_points, -> { order(:position) }, dependent: :destroy
 
   validates :number, presence: true
   validates :round, presence: true, if: -> { pool_number.blank? }
@@ -28,7 +27,7 @@ class Fight < ApplicationRecord
   validate :fighters_participate_in_category
   validate :winner_is_a_fighter
   validate :draw_constraints
-  validate :tiebreaker_constraints
+  validate :kettei_sen_constraints
 
   before_validation :restore_fighter_type
 
@@ -74,15 +73,6 @@ class Fight < ApplicationRecord
     [fighter_1, fighter_2, resolved_fighter_1, resolved_fighter_2, winner, bye_fighter].compact
   end
 
-  def points_for(slot)
-    side = (slot == 1) ? "fighter_1" : "fighter_2"
-    fight_points.select { |point| point.fighter_side == side }
-  end
-
-  def first_scoring_point
-    fight_points.reject { |point| point.kind == "hansoku" }.min_by(&:position)
-  end
-
   def resolved_fighter_1
     fighter_1 || parent_fight_1&.winner_or_bye
   end
@@ -121,35 +111,33 @@ class Fight < ApplicationRecord
     winner&.full_name
   end
 
-  # Derives a match's outcome from its recorded points: the side with more
-  # non-hansoku points wins. Equal points score a draw in a pool match (where
-  # draws are allowed) and stay unresolved in a bracket match; a match with no
-  # points is left unresolved. The winner is the resolved fighter on the leading
-  # side, so a bracket winner advances to the next round. Admins can still
-  # override the result; the override holds until the next point change.
-  # Returns true when the outcome actually changed (and was persisted), false
-  # when it was already up to date — the caller uses this to avoid a redundant
-  # standings refresh.
-  def recompute_outcome_from_points!
-    scored_1 = scoring_points_count("fighter_1")
-    scored_2 = scoring_points_count("fighter_2")
-
-    outcome =
-      if scored_1 > scored_2
-        {winner_id: resolved_fighter_1&.id, draw: false}
-      elsif scored_2 > scored_1
-        {winner_id: resolved_fighter_2&.id, draw: false}
-      elsif pool_number.present? && (scored_1.positive? || scored_2.positive?)
-        {winner_id: nil, draw: true}
-      else
-        {winner_id: nil, draw: false}
-      end
-
-    return false if winner_id == outcome[:winner_id] && draw == outcome[:draw]
-
-    update!(outcome)
-    true
+  # No real work recorded on this pool fight: no winner, not a draw, and no
+  # scored points. Used to decide whether rebuilding a pool (moving a
+  # participation between pools) is safe without explicit confirmation. Only
+  # meaningful for pool fights.
+  def pristine?
+    winner_id.nil? && !draw && fight_points.none?
   end
+
+  # --- Scorable hooks (preserve current individual-fight behavior) ---
+  def scoring_fighter(slot)
+    public_send(:"resolved_fighter_#{slot}")
+  end
+
+  def forfeit
+    nil # individual fights have no default/forfeit concept
+  end
+
+  def tie_outcome(scored_1, scored_2)
+    if pool_number.present? && (scored_1.positive? || scored_2.positive?)
+      {winner_id: nil, draw: true}
+    else
+      {winner_id: nil, draw: false}
+    end
+  end
+
+  # refresh_after_points is also a Scorable hook (defined below alongside
+  # refresh_pool_standings).
 
   # Recomputes/persists the pool standings and broadcasts the refreshed panel.
   # Driven from FightPoint's after_commit so the refresh always lands
@@ -164,8 +152,10 @@ class Fight < ApplicationRecord
     broadcast_pool_panel
   end
 
-  private def scoring_points_count(side)
-    fight_points.where(fighter_side: side).where.not(kind: "hansoku").count
+  # Refresh downstream state when a point did not change the outcome. For an
+  # individual fight this is the pool-standings panel (a no-op for bracket fights).
+  def refresh_after_points
+    refresh_pool_standings
   end
 
   private def broadcast_competition_tree
@@ -261,12 +251,12 @@ class Fight < ApplicationRecord
     errors.add(:draw, "cannot coexist with a winner") if winner_id.present?
   end
 
-  private def tiebreaker_constraints
+  private def kettei_sen_constraints
     return unless tiebreaker
 
     errors.add(:tiebreaker, "only allowed on pool fights") if pool_number.blank?
-    errors.add(:fighter_1, "is required for a tiebreaker") if fighter_1_id.blank?
-    errors.add(:fighter_2, "is required for a tiebreaker") if fighter_2_id.blank?
+    errors.add(:fighter_1, "is required for a kettei-sen") if fighter_1_id.blank?
+    errors.add(:fighter_2, "is required for a kettei-sen") if fighter_2_id.blank?
     if fighter_1_id.present? && fighter_1_id == fighter_2_id
       errors.add(:fighter_2, "must differ from fighter 1")
     end

--- a/app/models/fight_point.rb
+++ b/app/models/fight_point.rb
@@ -2,15 +2,11 @@
 
 class FightPoint < ApplicationRecord
   CODES = {
-    "men" => "M",
-    "kote" => "K",
-    "do" => "D",
-    "tsuki" => "T",
-    "ippon" => "I",
-    "hansoku" => "△"
+    "men" => "M", "kote" => "K", "do" => "D",
+    "tsuki" => "T", "ippon" => "I", "hansoku" => "△"
   }.freeze
 
-  belongs_to :fight, touch: true
+  belongs_to :scorable, polymorphic: true, touch: true
 
   enum :fighter_side, {fighter_1: "fighter_1", fighter_2: "fighter_2"}
   enum :kind, {
@@ -18,12 +14,12 @@ class FightPoint < ApplicationRecord
     tsuki: "tsuki", ippon: "ippon", hansoku: "hansoku"
   }
 
-  validates :position, presence: true, uniqueness: {scope: :fight_id}
+  validates :position, presence: true, uniqueness: {scope: [:scorable_type, :scorable_id]}
   validate :non_hansoku_point_limit_per_side, on: :create
 
   before_validation :assign_position, on: :create
 
-  after_commit :recompute_fight_outcome, on: [:create, :destroy]
+  after_commit :recompute_scorable_outcome, on: [:create, :destroy]
 
   scope :ordered, -> { order(:position) }
 
@@ -31,34 +27,33 @@ class FightPoint < ApplicationRecord
     CODES.fetch(kind)
   end
 
-  # Pool match outcomes are computed from the points, so any point change
-  # re-derives the owning fight's winner/draw. When the fight itself is being
-  # destroyed (its points cascade with it), the post-commit callback fires on
-  # the already-frozen fight — skip it, there is no outcome left to recompute.
-  #
-  # When the outcome changes, fight#update! already refreshed and broadcast the
-  # pool standings via its own after_commit. Otherwise (a second point on the
-  # leading side, or a hansoku) refresh here so the panel still updates — and,
-  # crucially, post-commit so a second viewer never receives a stale render.
-  private def recompute_fight_outcome
-    return if fight.destroyed?
+  # When the owning record is being destroyed (its points cascade with it), the
+  # post-commit callback fires on the already-frozen record — skip it. Otherwise
+  # re-derive the outcome from points; when it did NOT change, ask the record to
+  # refresh its own downstream state (pool standings for a Fight, the encounter
+  # for a TeamFight) so a second viewer still sees a fresh, committed render.
+  private def recompute_scorable_outcome
+    return if scorable.destroyed?
 
-    outcome_changed = fight.recompute_outcome_from_points!
-    fight.refresh_pool_standings unless outcome_changed
+    outcome_changed = scorable.recompute_outcome_from_points!
+    scorable.refresh_after_points unless outcome_changed
   end
 
   private def assign_position
     return if position.present?
-    return if fight_id.blank?
+    return if scorable_id.blank?
 
-    self.position = (self.class.where(fight_id: fight_id).maximum(:position) || 0) + 1
+    self.position = (self.class.where(scorable_type: scorable_type, scorable_id: scorable_id)
+      .maximum(:position) || 0) + 1
   end
 
   private def non_hansoku_point_limit_per_side
     return if hansoku?
-    return if fight_id.blank? || fighter_side.blank?
+    return if scorable_id.blank? || fighter_side.blank?
 
-    existing = self.class.where(fight_id: fight_id, fighter_side: fighter_side).where.not(kind: "hansoku")
+    existing = self.class
+      .where(scorable_type: scorable_type, scorable_id: scorable_id, fighter_side: fighter_side)
+      .where.not(kind: "hansoku")
     return if existing.count < 2
 
     errors.add(:base, "Fighter already has 2 non-hansoku points")

--- a/app/models/individual_category_bracket_builder.rb
+++ b/app/models/individual_category_bracket_builder.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class IndividualCategoryBracketBuilder
-  Slot = Data.define(:pool_number, :pool_rank, :participation)
-
   def initialize(category, rebuild_started: false)
     @category = category
     @rebuild_started = rebuild_started
@@ -59,7 +57,7 @@ class IndividualCategoryBracketBuilder
   end
 
   private def create_first_round_fights
-    first_round_pairs.map.with_index(1) do |(slot_1, slot_2), position|
+    BracketSeeder.new(slot_specs).first_round_pairs.map.with_index(1) do |(slot_1, slot_2), position|
       attrs = {
         number: position,
         round: 1,
@@ -70,8 +68,8 @@ class IndividualCategoryBracketBuilder
         fighter_2_pool_number: slot_2&.pool_number,
         fighter_2_pool_rank: slot_2&.pool_rank
       }
-      attrs[:fighter_1_id] = slot_1.participation&.kenshi_id if slot_1
-      attrs[:fighter_2_id] = slot_2.participation&.kenshi_id if slot_2
+      attrs[:fighter_1_id] = slot_1.payload&.kenshi_id if slot_1
+      attrs[:fighter_2_id] = slot_2.payload&.kenshi_id if slot_2
       category.fights.create!(attrs)
     end
   end
@@ -97,120 +95,13 @@ class IndividualCategoryBracketBuilder
     end
   end
 
-  private def first_round_pairs
-    entries = slot_specs
-    return [] if entries.empty?
-    return [[entries.first, nil]] if entries.size == 1
-
-    top, bottom = assign_halves(entries)
-    return [[top.first, bottom.first]] if bracket_size == 2
-
-    build_half_units(top) + build_half_units(bottom)
-  end
-
-  # Split entries into a top and bottom half. The pools are cut into a low block
-  # (the first half of pool numbers) and a high block. A low-block pool sends its
-  # rank-1 to the top half and rank-2 to the bottom; a high-block pool does the
-  # reverse (odd ranks follow rank-1, even ranks follow rank-2). This keeps each
-  # pool's rank-1 and rank-2 in opposite halves, and — because the low/high cut
-  # spans the whole pool-number range — lets evenly-spaced byes (see select_byes)
-  # fall one per half.
-  private def assign_halves(entries)
-    low_block = pool_numbers.first((pool_numbers.size / 2.0).ceil)
-    top = []
-    bottom = []
-    entries.each do |slot|
-      in_low_block = low_block.include?(slot.pool_number)
-      ((slot.pool_rank.odd? == in_low_block) ? top : bottom) << slot
-    end
-    [sort_by_strength(top), sort_by_strength(bottom)]
-  end
-
-  # Build the round-1 units (pairs; [slot, nil] for byes) for one half, ordered
-  # by leading fighter so the round-1 column reads in pool-number order within
-  # the half. half_size is an even power of two (the B == 2 case returns
-  # earlier), so the post-bye `rest` cross_pool_match receives is always
-  # even-sized. Slots are unique by (pool_number, pool_rank), so
-  # `half_slots - byes` removes exactly the byes.
-  private def build_half_units(half_slots)
-    half_size = bracket_size / 2
-    byes = select_byes(half_slots, half_size - half_slots.size)
-    fights = cross_pool_match(sort_by_strength(half_slots - byes))
-    units = byes.map { |slot| [slot, nil] } + fights
-    units.sort_by { |pair| [pair.first.pool_number, pair.first.pool_rank] }
-  end
-
-  # Byes go to evenly-spaced pool winners (rank-1s) within the half, so the bye
-  # advantage is distributed across the pool-number range rather than always
-  # landing on the lowest-numbered pools. When a half has more byes than winners
-  # (a small field in a large bracket), the spread spills over the half's entries
-  # in rank-major order, so a pool may then receive more than one bye. Returns []
-  # when there are no byes — never forces one, which would drop a fighter.
-  private def select_byes(slots, byes_count)
-    return [] if byes_count <= 0
-
-    winners = slots.select { |slot| slot.pool_rank == 1 }.sort_by(&:pool_number)
-    source = (byes_count <= winners.size) ? winners : sort_by_strength(slots)
-    Array.new(byes_count) { |j| source[j * source.size / byes_count] }
-  end
-
-  # Match the (even-sized, strength-sorted) `rest` into cross-pool fights. The
-  # greedy pass gives the most legible draw (a winner vs another pool's
-  # runner-up) but is a heuristic that can still leave a same-pool pair even when
-  # a cross-pool matching exists; grouped_cross_pool is the guaranteed fallback.
-  private def cross_pool_match(rest)
-    fights = greedy_cross_pool(rest)
-    same_pool?(fights) ? grouped_cross_pool(rest) : fights
-  end
-
-  # Pair each stronger entry with the next weaker entry from a different pool.
-  # `|| 0` only fires when no different-pool entry remains (a single pool filling
-  # the half, i.e. P == 1, where a same-pool meeting is unavoidable).
-  private def greedy_cross_pool(rest)
-    count = rest.size / 2
-    weaker = rest.last(count)
-    rest.first(count).map do |slot_1|
-      index = weaker.index { |slot| slot.pool_number != slot_1.pool_number } || 0
-      [slot_1, weaker.delete_at(index)]
-    end
-  end
-
-  # Guaranteed cross-pool matching: group by pool (largest first), pair i with
-  # i + half. Same-pool-free because select_byes caps every pool at <= rest/2.
-  private def grouped_cross_pool(rest)
-    grouped = rest.sort_by { |slot|
-      [-rest.count { |other| other.pool_number == slot.pool_number }, slot.pool_number, slot.pool_rank]
-    }
-    half = rest.size / 2
-    (0...half).map { |i| [grouped[i], grouped[i + half]] }
-  end
-
-  private def same_pool?(fights)
-    fights.any? { |slot_1, slot_2| slot_1 && slot_2 && slot_1.pool_number == slot_2.pool_number }
-  end
-
-  private def sort_by_strength(slots)
-    slots.sort_by { |slot| strength_key(slot) }
-  end
-
-  # Rank-major: lower rank, then lower pool number, is stronger.
-  private def strength_key(slot)
-    [slot.pool_rank, slot.pool_number]
-  end
-
-  private def bracket_size
-    return 0 if slot_specs.empty?
-
-    2**Math.log2(slot_specs.size).ceil
-  end
-
   private def slot_specs
     @slot_specs ||= (1..category.out_of_pool.to_i).flat_map do |pool_rank|
       pool_numbers.map do |pool_number|
-        Slot.new(
+        BracketSeeder::Slot.new(
           pool_number: pool_number,
           pool_rank: pool_rank,
-          participation: participations_by_slot[[pool_number, pool_rank]]
+          payload: participations_by_slot[[pool_number, pool_rank]]
         )
       end
     end

--- a/app/models/team_category.rb
+++ b/app/models/team_category.rb
@@ -9,10 +9,46 @@ class TeamCategory < ApplicationRecord
   has_many :videos, as: :category, dependent: :destroy
   has_many :documents, as: :category, dependent: :destroy
   has_many :kenshis, through: :teams
+  has_many :encounters, dependent: :destroy
+  # Bracket encounters are the elimination-tree nodes: no pool_number AND a round.
+  # The round guard excludes ad-hoc encounters created via the manual "new
+  # encounter" form (pool_number nil, round nil), which otherwise pollute the
+  # bracket and break the tree layout / builder idempotency.
+  has_many :bracket_encounters, -> { where(pool_number: nil).where.not(round: nil) },
+    class_name: "Encounter", inverse_of: :team_category
+
+  validates :team_size, inclusion: {in: [3, 5]}
 
   delegate :year, to: :cup
 
   def full_name
     "#{name} (#{cup.year})"
+  end
+
+  # No pool phase: teams go straight into the elimination bracket. The <= 1
+  # threshold matches TeamPooler, which clears pools for these categories.
+  def bracket_only?
+    pool_size.to_i <= 1
+  end
+
+  # NOT memoized: regeneration paths (TeamPoolMove -> PoolEncounterGenerator)
+  # reuse one category instance and re-read this after mutating pool membership,
+  # so a cached snapshot would regenerate pools from stale membership. Callers
+  # that read it repeatedly within a single render pass it down as a local.
+  def team_pools
+    teams.where.not(pool_number: nil).group_by(&:pool_number).sort.map do |number, pool_teams|
+      TeamPool.new(number: number, teams: pool_teams)
+    end
+  end
+
+  def encounters_by_pool_number
+    @encounters_by_pool_number ||= encounters.where.not(pool_number: nil)
+      .includes(:winner, team_1: :kenshis, team_2: :kenshis,
+        team_fights: [:fight_points, :kenshi_1, :kenshi_2, :winner])
+      .group_by(&:pool_number)
+  end
+
+  def set_team_pools(random: Random.new)
+    TeamPooler.new(self, random: random).set_pools
   end
 end

--- a/app/models/team_category_bracket_builder.rb
+++ b/app/models/team_category_bracket_builder.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+# Builds a single-elimination bracket of Encounters for a TeamCategory. Pooled
+# categories seed from pool standings (teams.pool_number / pool_rank via
+# BracketSeeder); bracket-only categories (TeamCategory#bracket_only?) draw
+# directly from teams via BracketOnlySeeder, fully resolved at creation with
+# no pool metadata. Mirrors IndividualCategoryBracketBuilder but operates on
+# Teams/Encounters, and FORWARD-PROPAGATES resolved teams into child slots
+# (see Encounter#assign_team_to_slot) rather than resolving lazily on read.
+class TeamCategoryBracketBuilder
+  def initialize(category, rebuild_started: false, random: Random.new)
+    @category = category
+    @rebuild_started = rebuild_started
+    @random = random
+  end
+
+  def call
+    return [] if first_round_pairs.empty?
+
+    category.transaction do
+      if category.bracket_encounters.empty?
+        create_new_bracket
+      elsif rebuild_started
+        # Higher rounds hold FKs to their parents; destroy children first.
+        category.bracket_encounters.order(round: :desc).destroy_all
+        create_new_bracket
+      else
+        update_existing_bracket
+      end
+    end
+    category.bracket_encounters.bracket_order.to_a
+  end
+
+  private attr_reader :category, :rebuild_started, :random
+
+  private def create_new_bracket
+    first_round = create_first_round_encounters
+    create_parent_rounds(first_round)
+  end
+
+  private def create_first_round_encounters
+    first_round_pairs.map.with_index(1) do |(slot_1, slot_2), position|
+      attrs = {
+        number: position,
+        round: 1,
+        position: position,
+        team_1_pool_number: slot_1&.pool_number,
+        team_1_pool_rank: slot_1&.pool_rank,
+        team_2_pool_number: slot_2&.pool_number,
+        team_2_pool_rank: slot_2&.pool_rank
+      }
+      attrs[:team_1_id] = slot_1.payload&.id if slot_1
+      attrs[:team_2_id] = slot_2.payload&.id if slot_2
+      category.encounters.create!(attrs)
+    end
+  end
+
+  # Wires parent_encounter_1/2 for rounds >= 2. A round-1 bye's occupant is
+  # deterministic and its winner never changes, so seed it straight into the
+  # child slot at build time (first fill — no sub-state to invalidate).
+  private def create_parent_rounds(child_encounters)
+    encounters = child_encounters
+    round = 2
+    number = child_encounters.size
+
+    while encounters.size > 1
+      encounters = encounters.each_slice(2).map.with_index(1) do |(parent_1, parent_2), position|
+        number += 1
+        category.encounters.create!(
+          number: number,
+          round: round,
+          position: position,
+          parent_encounter_1: parent_1,
+          parent_encounter_2: parent_2,
+          team_1_id: (parent_1.bye_team&.id if parent_1&.bye?),
+          team_2_id: (parent_2.bye_team&.id if parent_2&.bye?)
+        )
+      end
+      round += 1
+    end
+  end
+
+  private def update_existing_bracket
+    category.bracket_encounters.where(round: 1)
+      .includes(team_fights: :fight_points).find_each do |encounter|
+      # A non-force update only fills freshly-resolved slots; it must never
+      # disturb an encounter with work in progress (a set lineup, scored bouts,
+      # or a recorded winner). Re-resolving such a slot would invalidate that
+      # side's lineup and destroy its points. Discarding that work is what the
+      # explicit "Force rebuild" path (rebuild_started) is for.
+      next unless encounter.pristine?
+
+      [1, 2].each { |slot| update_team_slot(encounter, slot) }
+    end
+  end
+
+  private def update_team_slot(encounter, slot)
+    pool_number = encounter.public_send(:"team_#{slot}_pool_number")
+    pool_rank = encounter.public_send(:"team_#{slot}_pool_rank")
+    return if pool_number.blank? || pool_rank.blank?
+
+    team = teams_by_slot[[pool_number, pool_rank]]
+    encounter.assign_team_to_slot(slot, team)
+  end
+
+  private def first_round_pairs
+    @first_round_pairs ||= if category.bracket_only?
+      bracket_only_pairs
+    else
+      BracketSeeder.new(slot_specs).first_round_pairs
+    end
+  end
+
+  # Bracket-only round-1 slots carry no pool metadata; wrapping teams in
+  # nil-filled Slots keeps create_first_round_encounters shared between modes.
+  private def bracket_only_pairs
+    BracketOnlySeeder.new(category.teams.order(:id), random: random).first_round_pairs.map do |pair|
+      pair.map { |team| team && BracketSeeder::Slot.new(pool_number: nil, pool_rank: nil, payload: team) }
+    end
+  end
+
+  private def slot_specs
+    @slot_specs ||= (1..category.out_of_pool.to_i).flat_map do |pool_rank|
+      pool_numbers.map do |pool_number|
+        BracketSeeder::Slot.new(
+          pool_number: pool_number,
+          pool_rank: pool_rank,
+          payload: teams_by_slot[[pool_number, pool_rank]]
+        )
+      end
+    end
+  end
+
+  private def pool_numbers
+    @pool_numbers ||= category.teams
+      .where.not(pool_number: nil)
+      .distinct
+      .pluck(:pool_number)
+      .sort
+  end
+
+  private def teams_by_slot
+    @teams_by_slot ||= category.teams
+      .where.not(pool_number: nil)
+      .where.not(pool_rank: nil)
+      .index_by { |team| [team.pool_number, team.pool_rank] }
+  end
+end

--- a/app/models/team_fight.rb
+++ b/app/models/team_fight.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+class TeamFight < ApplicationRecord
+  include Scorable
+
+  belongs_to :encounter, touch: true
+  belongs_to :kenshi_1, class_name: "Kenshi", optional: true
+  belongs_to :kenshi_2, class_name: "Kenshi", optional: true
+  belongs_to :winner, class_name: "Kenshi", optional: true
+
+  after_update_commit :refresh_encounter, if: -> { saved_change_to_winner_id? || saved_change_to_draw? }
+
+  # Points credited to a side for the encounter ippon count: a forfeit gives the
+  # present side 2 (rule: a default is a loss, opponent gets 2 points).
+  def individual_points(slot)
+    return 2 if forfeit && forfeit == public_send(:"kenshi_#{slot}")
+    return 0 if forfeit
+
+    # Display/standings read: count off the (preloaded) association in memory so
+    # rolling an encounter up to ippons reuses loaded points instead of a COUNT
+    # per bout. points_for is a plain in-memory select on fight_points.
+    points_for(slot).count { |point| point.kind != "hansoku" }
+  end
+
+  # Called by EncounterLineup once BOTH lineups are in. Resolves only the
+  # structural outcome — a forfeit win, or clearing a stale forfeit winner when a
+  # re-entered lineup fills the empty side. It never marks an unfought both-present
+  # fight as a 0-0 hikiwake; that draw is the admin's explicit call during scoring.
+  def resolve_lineup!
+    if forfeit
+      update!(winner_id: forfeit.id, draw: false) unless winner_id == forfeit.id && !draw
+    elsif fight_points.empty? && (winner_id.present? || draw)
+      update!(winner_id: nil, draw: false)
+    end
+  end
+
+  # --- Scorable hooks ---
+  def scoring_fighter(slot)
+    public_send(:"kenshi_#{slot}")
+  end
+
+  # Both slots empty — a position neither short team filled. Counts for no one
+  # and must not block encounter completeness.
+  def void?
+    kenshi_1_id.nil? && kenshi_2_id.nil?
+  end
+
+  # A bout the admin may mark hikiwake by hand: a confirmed, both-present,
+  # unscored, undecided regular bout. The 0-0 both-present case is the only one
+  # not already settled by points or forfeit resolution. Gating on the lineup
+  # flags matters because auto-seeded fighters persist before confirmation, and
+  # a pre-confirmation draw would be wiped by resolve_lineup! on confirmation.
+  def hikiwake_eligible?
+    !daihyosen? && !void? && forfeit.nil? && fight_points.none? &&
+      winner_id.nil? && encounter.lineup_1_set? && encounter.lineup_2_set?
+  end
+
+  # Exactly one side empty => that side forfeits; the present kenshi wins.
+  def forfeit
+    return nil if kenshi_1_id.present? == kenshi_2_id.present?
+
+    kenshi_1 || kenshi_2
+  end
+
+  def tie_outcome(scored_1, scored_2)
+    if daihyosen?
+      {winner_id: nil, draw: false} # ippon-shobu: undecided until someone scores
+    elsif void? || (scored_1.zero? && scored_2.zero?)
+      # A void bout (an unfilled position) is no contest; a 0-0 with no points is
+      # unscored. Either way leave the bout pending — a genuine 0-0 hikiwake is
+      # the admin's explicit call (Admin::TeamFightsController), never an
+      # automatic consequence of deleting the last recorded point.
+      {winner_id: nil, draw: false}
+    else
+      {winner_id: nil, draw: true}  # hikiwake (e.g. 1-1)
+    end
+  end
+
+  def refresh_after_points
+    refresh_encounter
+  end
+
+  private def refresh_encounter
+    encounter.recompute_winner!
+    broadcast_replace_later_to(
+      [encounter, :panel],
+      target: ActionView::RecordIdentifier.dom_id(encounter),
+      partial: "admin/encounters/panel",
+      locals: {encounter: encounter, admin: true},
+      attributes: {method: :morph}
+    )
+    return if encounter.pool_number.blank?
+
+    broadcast_replace_later_to(
+      [encounter.team_category, :team_pools],
+      target: "team_pool_standings_#{encounter.team_category_id}_#{encounter.pool_number}",
+      partial: "admin/team_categories/pool_standings",
+      locals: {team_category: encounter.team_category, pool_number: encounter.pool_number, admin: true},
+      attributes: {method: :morph}
+    )
+    # The <summary> is pool-view content, so it rides the pool stream (which the
+    # pool card subscribes to) rather than the encounter's own panel stream —
+    # keeps the standalone encounter page from receiving an irrelevant morph.
+    broadcast_replace_later_to(
+      [encounter.team_category, :team_pools],
+      target: ActionView::RecordIdentifier.dom_id(encounter, :summary),
+      partial: "admin/encounters/summary",
+      locals: {encounter: encounter},
+      attributes: {method: :morph}
+    )
+  end
+end

--- a/app/models/team_pool.rb
+++ b/app/models/team_pool.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Transient grouping of a team category's teams that share a pool_number,
+# ordered by pool_position (the sibling of Pool for individual categories).
+class TeamPool
+  attr_reader :number, :teams
+
+  def initialize(number:, teams:)
+    @number = number
+    @teams = teams.sort_by { |team| team.pool_position || Float::INFINITY }
+  end
+end

--- a/app/models/team_pooler.rb
+++ b/app/models/team_pooler.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Distributes a team category's teams into pools (sibling of SmartPooler).
+# The seed-marked teams (medalists) go into distinct pools first; the rest are
+# drawn at random into the remaining open slots. Pools hold pool_size or
+# pool_size - 1 teams, with the larger pools first. Accepts an injected RNG so a
+# layout is reproducible.
+class TeamPooler
+  def initialize(team_category, random: Random.new)
+    @team_category = team_category
+    @random = random
+    @pool_size = team_category.pool_size.to_i
+    @teams = team_category.teams.order(:id).to_a
+  end
+
+  def set_pools
+    return clear_pools! if @pool_size <= 1
+    return if @teams.empty?
+
+    pools = Array.new(pool_count) { [] }
+    place_seeds(pools)
+    draw_rest(pools)
+    persist!(pools)
+  end
+
+  private attr_reader :team_category, :random, :teams, :pool_size
+
+  private def pool_count
+    [(teams.size.to_f / pool_size).ceil, 1].max
+  end
+
+  # Larger pools first: with N teams and P pools, the first (N mod P) pools hold
+  # ceil, the rest floor. e.g. 11 teams, P=4 -> [3,3,3,2].
+  private def target_sizes
+    base, remainder = teams.size.divmod(pool_count)
+    Array.new(pool_count) { |i| (i < remainder) ? base + 1 : base }
+  end
+
+  private def place_seeds(pools)
+    seeded = teams.select { |t| t.seed.present? }.sort_by(&:seed)
+    seeded.each_with_index { |team, i| pools[i % pool_count] << team }
+  end
+
+  private def draw_rest(pools)
+    sizes = target_sizes
+    unseeded = teams.reject { |t| t.seed.present? }.shuffle(random: random)
+    unseeded.each do |team|
+      pool_index = (0...pools.size).find { |i| pools[i].size < sizes[i] }
+      pools[pool_index] << team
+    end
+  end
+
+  private def persist!(pools)
+    Team.transaction do
+      pools.each_with_index do |members, i|
+        members.each_with_index do |team, j|
+          team.update!(pool_number: i + 1, pool_position: j + 1)
+        end
+      end
+    end
+  end
+
+  private def clear_pools!
+    Team.transaction do
+      teams.each do |team|
+        next if team.pool_number.nil? && team.pool_position.nil?
+
+        team.update!(pool_number: nil, pool_position: nil)
+      end
+    end
+  end
+end

--- a/app/models/team_position.rb
+++ b/app/models/team_position.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Kendo team-fighting role names by bout position. A full five-fighter team
+# fights sempō, jihō, chūken, fukushō, taishō; a three-fighter team keeps the
+# leadoff, centre and anchor roles (sempō, chūken, taishō). Sizes without a
+# conventional naming fall back to a plain "Position N" so the label is always
+# present.
+class TeamPosition
+  ROLES = {
+    5 => %w[Sempo Jiho Chuken Fukusho Taisho],
+    3 => %w[Sempo Chuken Taisho]
+  }.freeze
+
+  # e.g. "1. Sempo" for position 1 of a team of 5, or "Position 2" when the
+  # team size has no conventional role names.
+  def self.label(position, team_size)
+    role = ROLES[team_size]&.[](position - 1)
+    role ? "#{position}. #{role}" : "Position #{position}"
+  end
+end

--- a/app/pdfs/team_category_bracket_pdf.rb
+++ b/app/pdfs/team_category_bracket_pdf.rb
@@ -1,0 +1,408 @@
+# frozen_string_literal: true
+
+# The team-category counterpart of CompetitionTreePdf: a printable single
+# -elimination bracket. Each card is an Encounter (a team-vs-team tie) instead
+# of an individual Fight, so the per-fighter point codes become each side's
+# bout-win tally; everything else — pagination, connectors, the calling number
+# badge — mirrors the individual tree so both PDFs read identically.
+class TeamCategoryBracketPdf < Prawn::Document
+  CARD_WIDTH_MIN = 80
+  CARD_WIDTH_MAX = 180
+  GAP_RATIO = 18.0 / 110
+  FIGHTER_LINE_HEIGHT = 12
+  CARD_HEIGHT = 30
+  BYE_CARD_HEIGHT = 18
+  MATCH_GAP = 5
+  HEADER_HEIGHT = 28
+  ROUND_LABEL_AREA = 24
+  CARD_FIGHTER_GAP = 2
+  CARD_TEXT_INDENT = 4
+  NUMBER_BADGE_WIDTH = 22
+  NUMBER_BADGE_SIZE = 16
+  NUMBER_BADGE_COLOR = "C0392B"
+
+  FONT_DIR = Rails.root.join("vendor/fonts/inter").freeze
+
+  def initialize(team_category)
+    super(page_size: "A4", page_layout: :landscape, margin: 24)
+    register_inter_font
+    @team_category = team_category
+    @encounters = team_category.bracket_encounters
+      .includes(:team_1, :team_2, :winner, team_fights: :fight_points)
+      .bracket_order.to_a
+    Encounter.preload_parents(@encounters)
+
+    if @encounters.empty?
+      render_empty_state
+    else
+      panels = paginate_panels
+      panels.each_with_index do |panel, page_index|
+        start_new_page layout: :landscape if page_index.positive?
+        render_panel(panel, page_index, panels.size)
+      end
+    end
+  end
+
+  # Inter renders the on-screen hansoku glyph (△) and other Unicode that
+  # Prawn's built-in Helvetica cannot, which is limited to Windows-1252.
+  private def register_inter_font
+    font_families.update(
+      "Inter" => {
+        normal: FONT_DIR.join("Inter-Regular.ttf").to_s,
+        bold: FONT_DIR.join("Inter-Bold.ttf").to_s,
+        italic: FONT_DIR.join("Inter-Italic.ttf").to_s
+      }
+    )
+    font "Inter"
+  end
+
+  private attr_reader :team_category, :encounters
+
+  private def card_width
+    @card_width ||= begin
+      return CARD_WIDTH_MAX.to_f if total_rounds <= 0
+
+      total_units = total_rounds + (total_rounds - 1) * GAP_RATIO
+      raw = bounds.width / total_units
+      raw.clamp(CARD_WIDTH_MIN.to_f, CARD_WIDTH_MAX.to_f)
+    end
+  end
+
+  private def round_gap
+    return 0.0 if total_rounds <= 1
+
+    remaining = bounds.width - total_rounds * card_width
+    [remaining / (total_rounds - 1), card_width * GAP_RATIO].max
+  end
+
+  private def total_rounds
+    @total_rounds ||= encounters.map(&:round).max.to_i
+  end
+
+  private def render_empty_state
+    text "#{team_category.name} — no bracket generated", size: 14
+  end
+
+  private def render_panel(panel, page_index, total_pages)
+    render_header(panel, page_index, total_pages)
+    panel[:encounters_by_round].each do |round, round_encounters|
+      render_round(panel, round, round_encounters, page_index)
+    end
+  end
+
+  private def render_header(panel, page_index, total_pages)
+    bounding_box [bounds.left, bounds.top], width: bounds.width, height: HEADER_HEIGHT do
+      font_size 14 do
+        text team_category.name, style: :bold
+      end
+      footnote = if total_pages > 1
+        " — Panel #{page_index + 1} of #{total_pages} (R1 encounters #{panel[:label]})"
+      else
+        ""
+      end
+      font_size 9 do
+        text "Bracket#{footnote}", color: "000000"
+      end
+    end
+  end
+
+  private def render_round(panel, round, round_encounters, page_index)
+    round_index = round - 1
+    x_origin = bounds.left + round_index * (card_width + round_gap)
+
+    if page_index.zero?
+      bounding_box [x_origin, bounds.top - HEADER_HEIGHT - 6], width: card_width do
+        font_size 7 do
+          text "ROUND #{round}", color: "000000", style: :bold
+        end
+      end
+    end
+
+    round_encounters.each do |encounter|
+      next unless encounter_belongs_to_panel?(encounter, panel)
+      next unless encounter_visible_on_panel?(encounter, panel)
+
+      draw_card(encounter, x_origin, panel)
+      draw_connectors(encounter, x_origin, panel)
+    end
+  end
+
+  private def draw_card(encounter, x, panel)
+    y_center = panel_card_center_y(encounter, panel)
+    height = encounter.bye? ? BYE_CARD_HEIGHT : CARD_HEIGHT
+    card_top = y_center + height / 2.0
+
+    bounding_box [x, card_top], width: card_width, height: height do
+      stroke_color "000000"
+      line_width 0.75
+      dash 3 if encounter.bye?
+      stroke_bounds
+      undash
+
+      if encounter.bye?
+        # No "Bye" label or number — the dashed border already marks a bye.
+        move_down vertical_centering(height, rows: 1)
+        draw_bye_line(encounter)
+      else
+        draw_number_badge(encounter, height)
+        draw_match_teams(encounter, height)
+      end
+    end
+  end
+
+  # Top offset that vertically centers `rows` team lines within the card.
+  private def vertical_centering(height, rows:)
+    block = rows * FIGHTER_LINE_HEIGHT + (rows - 1) * CARD_FIGHTER_GAP
+    [(height - block) / 2.0, 0].max
+  end
+
+  # The encounter's display number, rendered large and bold in a column down the
+  # left edge so it stands out on a printed sheet for calling matches.
+  private def draw_number_badge(encounter, height)
+    number = display_number(encounter)
+    return if number.nil?
+
+    stroke_color "CCCCCC"
+    line_width 0.5
+    stroke do
+      move_to NUMBER_BADGE_WIDTH, 0
+      line_to NUMBER_BADGE_WIDTH, height
+    end
+    formatted_text_box(
+      [{text: number.to_s, color: NUMBER_BADGE_COLOR, styles: [:bold], size: NUMBER_BADGE_SIZE}],
+      at: [0, height],
+      width: NUMBER_BADGE_WIDTH,
+      height: height,
+      align: :center,
+      valign: :center,
+      overflow: :shrink_to_fit
+    )
+  end
+
+  # Top-aligned so the first team's highlight sits flush against the top of the
+  # card; the spare space falls below the second name instead.
+  private def draw_match_teams(encounter, height)
+    content_width = card_width - NUMBER_BADGE_WIDTH
+    draw_team_line(encounter, 1, left: NUMBER_BADGE_WIDTH, width: content_width)
+    move_down CARD_FIGHTER_GAP
+    draw_team_line(encounter, 2, left: NUMBER_BADGE_WIDTH, width: content_width)
+  end
+
+  private def draw_card_text(text, size:, left: 0, width: card_width, bold: false, color: "000000",
+    italic: false, background: nil, suffix: nil)
+    line_height = size + 2
+    styles = []
+    styles << :bold if bold
+    styles << :italic if italic
+    if background
+      previous_fill = fill_color
+      fill_color background
+      fill_rectangle [left, cursor], width, line_height + 2
+      fill_color previous_fill
+    end
+    font_size size do
+      suffix_width = suffix.present? ? suffix_width_for(suffix, bold: bold) : 0
+      reserved = suffix_width.positive? ? suffix_width + CARD_TEXT_INDENT : 0
+      formatted_text_box(
+        [{text: text, color: color, styles: styles}],
+        at: [left + CARD_TEXT_INDENT, cursor],
+        width: width - 2 * CARD_TEXT_INDENT - reserved,
+        height: line_height,
+        single_line: true,
+        valign: :center,
+        overflow: :shrink_to_fit
+      )
+      if suffix.present?
+        formatted_text_box(
+          [{text: suffix, color: color, styles: styles}],
+          at: [left + width - CARD_TEXT_INDENT - suffix_width, cursor],
+          width: suffix_width,
+          height: line_height,
+          single_line: true,
+          valign: :center,
+          overflow: :shrink_to_fit
+        )
+      end
+    end
+    move_down line_height
+  end
+
+  private def display_numbers
+    @display_numbers ||= BracketDisplayNumbering.for(encounters)
+  end
+
+  private def display_number(encounter)
+    display_numbers[encounter.id]
+  end
+
+  # width_of measures with the current (regular) font, but the suffix may be
+  # rendered bold. Pad the measured width so the rendered glyphs fit.
+  private def suffix_width_for(suffix, bold:)
+    raw = width_of(suffix)
+    raw *= 1.15 if bold
+    raw.ceil + 2
+  end
+
+  private def draw_bye_line(encounter)
+    slot = encounter.bye_slot
+    team = encounter.bye_team
+    label = team ? prefixed_name(encounter, slot, team) : fallback_label(encounter, slot)
+    draw_card_text label, size: 10, bold: team.present?, italic: team.blank?
+  end
+
+  private def draw_team_line(encounter, slot, left: 0, width: card_width)
+    team = encounter.public_send(:"resolved_team_#{slot}")
+    label = (team && prefixed_name(encounter, slot, team)) || fallback_label(encounter, slot)
+    bold = team.present? && encounter.winner == team
+    italic = team.blank?
+    background = (slot == 1) ? "FBA698" : nil
+    draw_card_text label, size: 10, left: left, width: width, bold: bold, italic: italic,
+      background: background, suffix: score_suffix(encounter, slot)
+  end
+
+  private def prefixed_name(encounter, slot, team)
+    prefix = seed_label(encounter, slot)
+    prefix ? "#{prefix} #{team.name}" : team.name
+  end
+
+  private def seed_label(encounter, slot)
+    return unless encounter.round == 1
+
+    pool_number = encounter.public_send(:"team_#{slot}_pool_number")
+    pool_rank = encounter.public_send(:"team_#{slot}_pool_rank")
+    return if pool_number.blank? || pool_rank.blank?
+
+    "#{pool_number}.#{pool_rank}"
+  end
+
+  # Each side's bout-win tally, shown only once the tie has fights — mirrors the
+  # on-screen score line, but split per row like the individual PDF's points.
+  private def score_suffix(encounter, slot)
+    return if encounter.team_fights.empty?
+
+    result = result_for(encounter)
+    (slot == 1) ? result.team_1_wins.to_s : result.team_2_wins.to_s
+  end
+
+  private def result_for(encounter)
+    @results ||= {}
+    @results[encounter.id] ||= encounter.result
+  end
+
+  private def fallback_label(encounter, slot)
+    parent_encounter = encounter.public_send(:"parent_encounter_#{slot}")
+    return "Waiting for encounter #{display_number(parent_encounter)}" if parent_encounter.present?
+
+    seed_label(encounter, slot) || ""
+  end
+
+  private def draw_connectors(encounter, x, panel)
+    [encounter.parent_encounter_1, encounter.parent_encounter_2].compact.each do |parent_encounter|
+      draw_connector(parent_encounter, encounter, panel)
+    end
+    children_of(encounter).each do |child|
+      next if same_panel?(encounter, child, panel)
+      draw_connector(encounter, child, panel)
+    end
+  end
+
+  private def children_of(encounter)
+    children_by_parent_id[encounter.id] || []
+  end
+
+  private def children_by_parent_id
+    @children_by_parent_id ||= encounters.each_with_object({}) do |e, hash|
+      [e.parent_encounter_1_id, e.parent_encounter_2_id].compact.each do |parent_id|
+        (hash[parent_id] ||= []) << e
+      end
+    end
+  end
+
+  private def draw_connector(parent_encounter, encounter, panel)
+    parent_x = bounds.left + (parent_encounter.round - 1) * (card_width + round_gap) + card_width
+    parent_y = panel_card_center_y(parent_encounter, panel)
+    child_x = bounds.left + (encounter.round - 1) * (card_width + round_gap)
+    child_y = panel_card_center_y(encounter, panel)
+    elbow = parent_x + (child_x - parent_x) / 2.0
+
+    stroke_color "000000"
+    line_width 0.75
+    stroke do
+      move_to parent_x, parent_y
+      line_to elbow, parent_y
+      line_to elbow, child_y
+      line_to child_x, child_y
+    end
+  end
+
+  private def panel_card_center_y(encounter, panel)
+    span = 2**(encounter.round - 1)
+    first_slot_index = (encounter.position - 1) * span - panel[:slot_offset]
+    slot_pitch = CARD_HEIGHT + MATCH_GAP
+    middle_offset = (span - 1) / 2.0
+    canvas_top - HEADER_HEIGHT - ROUND_LABEL_AREA - slot_pitch * (first_slot_index + middle_offset) - CARD_HEIGHT / 2.0
+  end
+
+  private def canvas_top
+    bounds.top
+  end
+
+  private def encounter_belongs_to_panel?(encounter, panel)
+    leaves_under(encounter).any? { |position| panel[:r1_positions].include?(position) }
+  end
+
+  private def encounter_visible_on_panel?(encounter, panel)
+    span = 2**(encounter.round - 1)
+    first_slot_index = (encounter.position - 1) * span - panel[:slot_offset]
+    middle_offset = (span - 1) / 2.0
+    combined = first_slot_index + middle_offset
+    combined >= 0 && combined < max_rows_per_page
+  end
+
+  private def same_panel?(parent_encounter, encounter, panel)
+    encounter_visible_on_panel?(parent_encounter, panel) && encounter_visible_on_panel?(encounter, panel)
+  end
+
+  private def leaves_under(encounter)
+    span = 2**(encounter.round - 1)
+    first = (encounter.position - 1) * span + 1
+    (first...(first + span)).to_a
+  end
+
+  private def paginate_panels
+    r1_count = encounters_by_round[1]&.size.to_i
+    return [build_panel((1..r1_count).to_a)] if r1_count.zero?
+
+    rows_per_page = max_rows_per_page
+    return [build_panel((1..r1_count).to_a)] if r1_count <= rows_per_page
+
+    panels = []
+    (1..r1_count).each_slice(rows_per_page) do |slice|
+      panels << build_panel(slice)
+    end
+    panels
+  end
+
+  private def build_panel(r1_positions)
+    slot_offset = r1_positions.first - 1
+    panel_encounters = encounters.select { |encounter|
+      leaves_under(encounter).any? { |position| r1_positions.include?(position) }
+    }
+    label = (r1_positions.size == 1) ? r1_positions.first.to_s : "#{r1_positions.first}-#{r1_positions.last}"
+    {
+      r1_positions: r1_positions,
+      slot_offset: slot_offset,
+      label: label,
+      encounters_by_round: panel_encounters.group_by(&:round).sort.to_h
+    }
+  end
+
+  private def encounters_by_round
+    @encounters_by_round ||= encounters.group_by(&:round)
+  end
+
+  private def max_rows_per_page
+    available = bounds.height - HEADER_HEIGHT - ROUND_LABEL_AREA
+    [(available / (CARD_HEIGHT + MATCH_GAP)).floor, 1].max
+  end
+end

--- a/app/services/bracket_display_numbering.rb
+++ b/app/services/bracket_display_numbering.rb
@@ -1,50 +1,50 @@
 # frozen_string_literal: true
 
-# Assigns each bracket fight a display number: a secondary, viewer-facing
-# numbering distinct from the canonical `number`. BYE fights are skipped (they
-# are never contested), and real matches are numbered to the highest round
-# possible — a parent (later round) is numbered as soon as both of its feeder
-# subtrees are exhausted. This is a post-order depth-first traversal of the
-# tree rooted at the final, so the resulting order matches how the matches will
-# actually be fought.
-#
-# Returns a Hash of { fight_id => display_number }; BYE fights are absent.
+# Assigns each bracket node a stable, leaf-first display number (byes skipped),
+# matching the order results are entered. Works on any node type that defines a
+# PARENT_ASSOCIATIONS constant ([:parent_fight_1, :parent_fight_2] for Fight,
+# [:parent_encounter_1, :parent_encounter_2] for Encounter) and responds to
+# #bye?, #round, #position, #id. Parents must be preloaded (Fight.preload_parents
+# / Encounter.preload_parents) so traversal does not re-query.
 class BracketDisplayNumbering
-  def self.for(fights)
-    new(fights).numbers
+  def self.for(records)
+    new(records).numbers
   end
 
-  def initialize(fights)
-    @fights = fights
+  def initialize(records)
+    @records = records
   end
 
   def numbers
     @numbers = {}
     @counter = 0
-    root_fights.each { |fight| assign(fight) }
+    root_records.each { |record| assign(record) }
     @numbers
   end
 
-  private attr_reader :fights
+  private attr_reader :records
 
-  private def assign(fight)
-    return if fight.nil?
+  private def assign(record)
+    return if record.nil?
 
-    assign(fight.parent_fight_1)
-    assign(fight.parent_fight_2)
-    return if fight.bye?
+    parents(record).each { |parent| assign(parent) }
+    return if record.bye?
 
     @counter += 1
-    @numbers[fight.id] = @counter
+    @numbers[record.id] = @counter
   end
 
-  # The roots are the fights no other fight feeds into — a complete bracket has
-  # exactly one (the final). Sorted so disconnected trees number top-to-bottom.
-  private def root_fights
-    parent_ids = fights.flat_map { |fight|
-      [fight.parent_fight_1_id, fight.parent_fight_2_id]
-    }.compact.to_set
-    fights.reject { |fight| parent_ids.include?(fight.id) }
-      .sort_by { |fight| [fight.round.to_i, fight.position.to_i] }
+  private def parents(record)
+    record.class::PARENT_ASSOCIATIONS.map { |name| record.public_send(name) }
+  end
+
+  private def parent_ids_of(record)
+    record.class::PARENT_ASSOCIATIONS.map { |name| record.public_send(:"#{name}_id") }
+  end
+
+  private def root_records
+    referenced = records.flat_map { |record| parent_ids_of(record) }.compact.to_set
+    records.reject { |record| referenced.include?(record.id) }
+      .sort_by { |record| [record.round.to_i, record.position.to_i] }
   end
 end

--- a/app/services/bracket_only_seeder.rb
+++ b/app/services/bracket_only_seeder.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+# Classic single-elimination draw for a bracket-only team category (no pool
+# phase). Returns ordered round-1 pairs [team_or_nil, team_or_nil] (nil = a
+# bye), the same shape as BracketSeeder#first_round_pairs.
+#
+# NOT built on BracketSeeder: its pairing math assumes complete rank layers
+# (every pool number present at every rank it is fed), which bracket-only
+# input cannot satisfy, so this is a dedicated draw.
+#
+# teams.seed is an ordering hint, not an identifier: seeds order by [seed, id]
+# (lower = stronger; the id tie-break makes duplicate values deterministic).
+# Byes go to seeds first, then to randomly drawn unseeded teams. Units holding
+# a seed take the standard protected positions (top, bottom, quarter
+# boundaries, ...); the rest fill the remaining positions at random.
+class BracketOnlySeeder
+  def initialize(teams, random: Random.new)
+    @teams = teams.to_a
+    @random = random
+  end
+
+  def first_round_pairs
+    return [] if teams.size < 2
+
+    place(bye_units + fight_units)
+  end
+
+  def bracket_size
+    return 0 if teams.size < 2
+
+    2**Math.log2(teams.size).ceil
+  end
+
+  private attr_reader :teams, :random
+
+  private def seeded
+    @seeded ||= teams.select { |team| team.seed.present? }
+      .sort_by { |team| [team.seed, team.id] }
+  end
+
+  private def unseeded
+    @unseeded ||= (teams - seeded).shuffle(random: random)
+  end
+
+  # Seeds first; remaining byes go to (already shuffled) unseeded teams.
+  private def bye_teams
+    @bye_teams ||= (seeded + unseeded).first(bracket_size - teams.size)
+  end
+
+  private def bye_units
+    bye_teams.map { |team| [team, nil] }
+  end
+
+  # Each remaining seed fights an unseeded opponent while any remain; leftover
+  # seeds (an all-seeded field) pair strongest vs weakest among themselves, and
+  # leftover unseeded teams pair in their (random) draw order. The remainder
+  # after byes is even (bracket_size - 2 * byes), so nobody is left over.
+  private def fight_units
+    seeds = seeded - bye_teams
+    others = unseeded - bye_teams
+    seed_fights = seeds.first(others.size).map { |seed| [seed, others.shift] }
+    leftover_seeds = seeds.drop(seed_fights.size)
+    seed_fights + strongest_vs_weakest(leftover_seeds) + others.each_slice(2).to_a
+  end
+
+  private def strongest_vs_weakest(list)
+    (0...list.size / 2).map { |i| [list[i], list[list.size - 1 - i]] }
+  end
+
+  # Units holding a seed go to the protected positions in seed-priority order,
+  # and remaining bye units take the next protected positions — the sequence
+  # is maximally spread, so no two byes meet in round 2 unless byes outnumber
+  # the round-2 slots. Only the fights are drawn into random positions.
+  # (Seeded fight units and unseeded byes never coexist: byes go to seeds
+  # first, so an unseeded bye implies every seed already holds one.)
+  private def place(units)
+    with_seed, rest = units.partition { |unit| seed_priority(unit) }
+    byes, fights = rest.partition { |unit| unit.last.nil? }
+    protected_units = with_seed.sort_by { |unit| seed_priority(unit) } + byes
+
+    positions = Array.new(units.size)
+    sequence = priority_positions(units.size)
+    protected_units.each_with_index { |unit, i| positions[sequence[i]] = unit }
+    open = (0...units.size).select { |i| positions[i].nil? }.shuffle(random: random)
+    fights.each { |unit| positions[open.shift] = unit }
+    positions
+  end
+
+  # A unit's priority is its strongest seed's index in the seed order.
+  private def seed_priority(unit)
+    unit.compact.filter_map { |team| seeded.index(team) }.min
+  end
+
+  # Seed-priority ordering of unit positions, following the standard bracket
+  # layout (projected semifinals 1v4 and 2v3, quarterfinals 1v8/4v5/3v6/2v7):
+  # build the classic replace-by-complement-pairs layout, mirror the bottom
+  # half so seed 2 sits at the very bottom, then read off each seed's unit
+  # index. unit count is always a power of two (bracket_size / 2).
+  private def priority_positions(count)
+    layout = [1]
+    while layout.size < count
+      doubled = layout.size * 2
+      layout = layout.flat_map { |seed| [seed, doubled + 1 - seed] }
+    end
+    half = count / 2
+    layout = layout.first(half) + layout.last(half).reverse if count > 1
+    (1..count).map { |seed| layout.index(seed) }
+  end
+end

--- a/app/services/bracket_seeder.rb
+++ b/app/services/bracket_seeder.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+# Pure single-elimination seeding over abstract Slots. Given an ordered,
+# rank-major list of Slot(pool_number, pool_rank, payload), returns the round-1
+# pairing as [slot_or_nil, slot_or_nil] pairs (nil = a bye). Domain-agnostic:
+# callers build the slots and turn the resulting pairs into their own records.
+#
+# ASSUMES complete rank layers: every pool_number it is fed appears at every
+# pool_rank in the input (the pooled builder guarantees this). Sparse input —
+# e.g. bracket-only slot lists — breaks assign_halves balance and select_byes
+# uniqueness; that mode uses BracketOnlySeeder instead.
+class BracketSeeder
+  Slot = Data.define(:pool_number, :pool_rank, :payload)
+
+  def initialize(slots)
+    @slots = slots
+  end
+
+  def first_round_pairs
+    entries = @slots
+    return [] if entries.empty?
+    return [[entries.first, nil]] if entries.size == 1
+
+    top, bottom = assign_halves(entries)
+    return [[top.first, bottom.first]] if bracket_size == 2
+
+    build_half_units(top) + build_half_units(bottom)
+  end
+
+  def bracket_size
+    return 0 if @slots.empty?
+
+    2**Math.log2(@slots.size).ceil
+  end
+
+  # Derived from the input (was a DB query on the category in the old builder).
+  private def pool_numbers
+    @pool_numbers ||= @slots.map(&:pool_number).uniq.sort
+  end
+
+  # Split entries into a top and bottom half. The pools are cut into a low block
+  # (the first half of pool numbers) and a high block. A low-block pool sends its
+  # rank-1 to the top half and rank-2 to the bottom; a high-block pool does the
+  # reverse (odd ranks follow rank-1, even ranks follow rank-2). This keeps each
+  # pool's rank-1 and rank-2 in opposite halves, and — because the low/high cut
+  # spans the whole pool-number range — lets evenly-spaced byes (see select_byes)
+  # fall one per half.
+  private def assign_halves(entries)
+    low_block = pool_numbers.first((pool_numbers.size / 2.0).ceil)
+    top = []
+    bottom = []
+    entries.each do |slot|
+      in_low_block = low_block.include?(slot.pool_number)
+      ((slot.pool_rank.odd? == in_low_block) ? top : bottom) << slot
+    end
+    [sort_by_strength(top), sort_by_strength(bottom)]
+  end
+
+  # Build the round-1 units (pairs; [slot, nil] for byes) for one half, ordered
+  # by leading fighter so the round-1 column reads in pool-number order within
+  # the half. half_size is an even power of two (the B == 2 case returns
+  # earlier), so the post-bye `rest` cross_pool_match receives is always
+  # even-sized. Slots are unique by (pool_number, pool_rank), so
+  # `half_slots - byes` removes exactly the byes.
+  private def build_half_units(half_slots)
+    half_size = bracket_size / 2
+    byes = select_byes(half_slots, half_size - half_slots.size)
+    fights = cross_pool_match(sort_by_strength(half_slots - byes))
+    units = byes.map { |slot| [slot, nil] } + fights
+    units.sort_by { |pair| [pair.first.pool_number, pair.first.pool_rank] }
+  end
+
+  # Byes go to evenly-spaced pool winners (rank-1s) within the half, so the bye
+  # advantage is distributed across the pool-number range rather than always
+  # landing on the lowest-numbered pools. When a half has more byes than winners
+  # (a small field in a large bracket), the spread spills over the half's entries
+  # in rank-major order, so a pool may then receive more than one bye. Returns []
+  # when there are no byes — never forces one, which would drop a fighter.
+  private def select_byes(slots, byes_count)
+    return [] if byes_count <= 0
+
+    winners = slots.select { |slot| slot.pool_rank == 1 }.sort_by(&:pool_number)
+    source = (byes_count <= winners.size) ? winners : sort_by_strength(slots)
+    Array.new(byes_count) { |j| source[j * source.size / byes_count] }
+  end
+
+  # Match the (even-sized, strength-sorted) `rest` into cross-pool fights. The
+  # greedy pass gives the most legible draw (a winner vs another pool's
+  # runner-up) but is a heuristic that can still leave a same-pool pair even when
+  # a cross-pool matching exists; grouped_cross_pool is the guaranteed fallback.
+  private def cross_pool_match(rest)
+    fights = greedy_cross_pool(rest)
+    same_pool?(fights) ? grouped_cross_pool(rest) : fights
+  end
+
+  # Pair each stronger entry with the next weaker entry from a different pool.
+  # `|| 0` only fires when no different-pool entry remains (a single pool filling
+  # the half, i.e. P == 1, where a same-pool meeting is unavoidable).
+  private def greedy_cross_pool(rest)
+    count = rest.size / 2
+    weaker = rest.last(count)
+    rest.first(count).map do |slot_1|
+      index = weaker.index { |slot| slot.pool_number != slot_1.pool_number } || 0
+      [slot_1, weaker.delete_at(index)]
+    end
+  end
+
+  # Guaranteed cross-pool matching: group by pool (largest first), pair i with
+  # i + half. Same-pool-free because select_byes caps every pool at <= rest/2.
+  private def grouped_cross_pool(rest)
+    grouped = rest.sort_by { |slot|
+      [-rest.count { |other| other.pool_number == slot.pool_number }, slot.pool_number, slot.pool_rank]
+    }
+    half = rest.size / 2
+    (0...half).map { |i| [grouped[i], grouped[i + half]] }
+  end
+
+  private def same_pool?(fights)
+    fights.any? { |slot_1, slot_2| slot_1 && slot_2 && slot_1.pool_number == slot_2.pool_number }
+  end
+
+  private def sort_by_strength(slots)
+    slots.sort_by { |slot| strength_key(slot) }
+  end
+
+  # Rank-major: lower rank, then lower pool number, is stronger.
+  private def strength_key(slot)
+    [slot.pool_rank, slot.pool_number]
+  end
+end

--- a/app/services/daihyosen_proposal.rb
+++ b/app/services/daihyosen_proposal.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Auto-creates the daihyōsen bout when a bracket encounter is complete and level
+# (equal wins AND equal ippons), pre-filled with each team's taishō (last filled
+# position). Advisory: the bout is persisted but winner-less; the admin edits the
+# reps and scores it. No-op unless a tie genuinely needs deciding, and idempotent
+# under the concurrent scoring/draw callbacks that drive recompute_winner!.
+class DaihyosenProposal
+  def initialize(encounter)
+    @encounter = encounter
+  end
+
+  def ensure!
+    return if @encounter.pool_number.present?
+
+    result = @encounter.result
+    return unless result.complete? && result.winner.nil?
+    return if @encounter.team_fights.reload.any?(&:daihyosen?)
+
+    rep_1 = taisho(1)
+    rep_2 = taisho(2)
+    return unless rep_1 && rep_2 # degenerate all-void/forfeit tie: nothing to propose
+
+    @encounter.team_fights.create!(
+      daihyosen: true,
+      position: @encounter.team_size + 1,
+      kenshi_1_id: rep_1.id,
+      kenshi_2_id: rep_2.id
+    )
+    @encounter.team_fights.reset
+  rescue ActiveRecord::RecordNotUnique
+    # A concurrent recompute already created it; treat as success.
+    @encounter.team_fights.reset
+  end
+
+  # The fighter at the last filled regular position on this side, or nil.
+  private def taisho(slot)
+    @encounter.team_fights
+      .reject(&:daihyosen?)
+      .reverse_each
+      .filter_map { |fight| fight.public_send(:"kenshi_#{slot}") }
+      .first
+  end
+end

--- a/app/services/encounter_lineup.rb
+++ b/app/services/encounter_lineup.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# Assigns one team's ordered members to its side of every bout in an encounter,
+# creating the team_size TeamFight rows on first use. Positions past the supplied
+# list keep a nil kenshi on that side (a forfeit). Re-assigning a side overwrites
+# only that side's kenshi at each position.
+class EncounterLineup
+  class InvalidLineup < StandardError; end
+
+  def initialize(encounter)
+    @encounter = encounter
+    @team_size = encounter.team_size
+  end
+
+  # Confirm a side's lineup: write the fighters AND mark the side set, which is
+  # what lets the tie/daihyōsen prompt and forfeit resolution kick in.
+  def assign(team, kenshi_ids)
+    write_side(team, kenshi_ids, confirm: true)
+  end
+
+  # Pre-fill a side's order without confirming it: the fighters land in their
+  # bouts (so they can be reordered or scored) but lineup_#{slot}_set stays
+  # false, so an unfought encounter doesn't read as a complete (tied) one. The
+  # admin confirms later by editing, dragging, or scoring.
+  def seed(team, kenshi_ids)
+    write_side(team, kenshi_ids, confirm: false)
+  end
+
+  private def write_side(team, kenshi_ids, confirm:)
+    # Index i maps to position i+1; a nil/blank entry is a forfeit at THAT
+    # position, so keep it (don't compact) — compacting would slide every later
+    # fighter up a slot and push the gap to the end.
+    kenshi_ids = kenshi_ids.map { |id| id.presence&.to_i }
+    slot = slot_for(team)
+    validate!(team, kenshi_ids)
+
+    @encounter.transaction do
+      (1..@team_size).each do |position|
+        fight = @encounter.team_fights.find_or_create_by!(position: position)
+        current_kenshi_id = fight.public_send("kenshi_#{slot}_id")
+        new_kenshi_id = kenshi_ids[position - 1]
+        next if new_kenshi_id == current_kenshi_id
+
+        # Reordering or replacing a fighter who already fought a scored bout
+        # RESETS that bout — its points and recorded outcome belonged to the old
+        # matchup, so they're cleared. delete_all (not destroy_all) drops the
+        # points WITHOUT firing FightPoint's recompute callback, which would
+        # otherwise re-mark the now-empty both-present bout as a 0-0 hikiwake; we
+        # want it fully unresolved, ready to re-score. Filling an empty side
+        # (current is nil) is a late lineup entry, not a replacement, so it keeps
+        # the bout's existing points (e.g. an opponent's forfeit point stands).
+        if current_kenshi_id.present? && fight.fight_points.exists?
+          fight.fight_points.delete_all
+          fight.update!("kenshi_#{slot}_id": new_kenshi_id, winner_id: nil, draw: false)
+        else
+          fight.update!("kenshi_#{slot}_id": new_kenshi_id)
+        end
+      end
+      next unless confirm
+
+      @encounter.update!("lineup_#{slot}_set": true)
+      resolve_forfeits if @encounter.lineup_1_set? && @encounter.lineup_2_set?
+    end
+
+    # Post-commit: recompute_winner! is documented as never landing its write
+    # mid-transaction, so re-evaluate the daihyōsen need after the commit.
+    @encounter.recompute_winner! if confirm && @encounter.lineup_1_set? && @encounter.lineup_2_set?
+  end
+
+  private def resolve_forfeits
+    @encounter.team_fights.reset
+    @encounter.team_fights.each(&:resolve_lineup!)
+  end
+
+  private def slot_for(team)
+    return 1 if team.id == @encounter.team_1_id
+    return 2 if team.id == @encounter.team_2_id
+
+    raise InvalidLineup, "team is not part of this encounter"
+  end
+
+  private def validate!(team, kenshi_ids)
+    raise InvalidLineup, "too many members" if kenshi_ids.size > @team_size
+
+    # Blank slots (nil) are forfeits, not fighters: exclude them from the
+    # duplicate and membership checks so several gaps don't read as duplicates.
+    present = kenshi_ids.compact
+    raise InvalidLineup, "duplicate members" if present.uniq.size != present.size
+
+    on_team = team.kenshis.where(id: present).pluck(:id)
+    raise InvalidLineup, "member not on team" if (present - on_team).any?
+  end
+end

--- a/app/services/encounter_lineup_seeder.rb
+++ b/app/services/encounter_lineup_seeder.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Fills a fresh encounter's bouts with each side's suggested order (see
+# EncounterLineupSuggestion) and CONFIRMS it (lineup_#{slot}_set), so an opened
+# encounter is immediately usable — fighters are draggable, bouts can be marked
+# hikiwake, and the encounter can complete — without the admin re-entering an
+# already-correct lineup. A side already set, already populated, or with no valid
+# suggestion is left untouched. Confirming is safe because the tie/daihyōsen
+# logic keys off EncounterResult#complete? (which still needs fought bouts), so
+# this never produces a premature tie on an unfought encounter.
+# Best-effort: a suggestion gone stale (a member left the team) just skips that
+# side rather than failing the whole seed.
+class EncounterLineupSeeder
+  def initialize(encounter)
+    @encounter = encounter
+    @suggestion = EncounterLineupSuggestion.new(encounter)
+  end
+
+  def call
+    [1, 2].each { |slot| seed(slot) }
+    @encounter
+  end
+
+  private def seed(slot)
+    return if @encounter.public_send(:"lineup_#{slot}_set?")
+    return if populated?(slot)
+
+    team = @encounter.public_send(:"resolved_team_#{slot}")
+    return unless team
+
+    ids = @suggestion.for_slot(slot)
+    return if ids.compact.empty?
+
+    EncounterLineup.new(@encounter).assign(team, ids)
+  rescue EncounterLineup::InvalidLineup
+    nil # leave this side for manual entry
+  rescue ActiveRecord::RecordNotUnique
+    # The lineup Stimulus controller auto-POSTs a seed on connect, so two tablets
+    # (or a double-load) can open a fresh encounter at once: both pass the
+    # populated? guard (no bouts exist yet) and race find_or_create_by!(position:)
+    # on the (encounter_id, position) unique index. The loser's transaction rolls
+    # back here; the winner has seeded the side, so treat it as already-seeded
+    # rather than surfacing a 500 (mirrors DaihyosenProposal's race guard).
+    @encounter.team_fights.reset
+  end
+
+  private def populated?(slot)
+    column = (slot == 1) ? :kenshi_1_id : :kenshi_2_id
+    @encounter.team_fights.where(daihyosen: false).where.not(column => nil).exists?
+  end
+end

--- a/app/services/encounter_lineup_suggestion.rb
+++ b/app/services/encounter_lineup_suggestion.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Suggests a starting lineup order for one side of an encounter, so a fresh
+# encounter's dropdowns open pre-filled instead of blank. The suggestion is the
+# order the team used in its most recent OTHER encounter; failing that (the
+# team has not fought yet), its roster order. Teams keep a stable fighter order
+# across the tournament, so last time's order is almost always the right guess.
+#
+# This is advisory only — it never writes anything. The admin confirms it by
+# editing any slot, which submits the shown lineup through EncounterLineup.
+class EncounterLineupSuggestion
+  def initialize(encounter)
+    @encounter = encounter
+    @team_size = encounter.team_size
+  end
+
+  # An ordered list of kenshi ids (nil where a position was/should be a forfeit)
+  # for the resolved team on `slot`, capped at team_size. [] if no team yet.
+  def for_slot(slot)
+    team = @encounter.public_send(:"resolved_team_#{slot}")
+    return [] unless team
+
+    (previous_order(team) || roster_order(team)).first(@team_size)
+  end
+
+  private def previous_order(team)
+    encounter = candidate_encounters(team).order(updated_at: :desc, id: :desc).first
+    return unless encounter
+
+    side = (encounter.team_1_id == team.id) ? 1 : 2
+    encounter.team_fights.where(daihyosen: false).order(:position)
+      .pluck(:"kenshi_#{side}_id")
+  end
+
+  # Encounters (other than this one) where the team fought a side whose lineup
+  # was actually entered — a set lineup is what carries a meaningful order.
+  private def candidate_encounters(team)
+    @encounter.team_category.encounters
+      .where.not(id: @encounter.id)
+      .where(
+        "(team_1_id = :t AND lineup_1_set = TRUE) OR (team_2_id = :t AND lineup_2_set = TRUE)",
+        t: team.id
+      )
+  end
+
+  private def roster_order(team)
+    team.kenshis.pluck(:id)
+  end
+end

--- a/app/services/encounter_result.rb
+++ b/app/services/encounter_result.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Rolls an encounter's TeamFights up to a winning Team, per the rule precedence:
+# (1) most individual winners, (2) most points, (3) the daihyosen winner's team
+# (else unresolved). kenshi_1 belongs to team_1, kenshi_2 to team_2, so a fight
+# won by its kenshi_1 is a team_1 win — forfeits fold in via TeamFight#winner.
+class EncounterResult
+  def initialize(encounter)
+    @encounter = encounter
+    @fights = encounter.team_fights.to_a
+  end
+
+  def team_1_wins = regular.count { |tf| won_by?(tf, 1) }
+
+  def team_2_wins = regular.count { |tf| won_by?(tf, 2) }
+
+  def team_1_ippons = regular.sum { |tf| tf.individual_points(1) }
+
+  def team_2_ippons = regular.sum { |tf| tf.individual_points(2) }
+
+  def winner
+    return @encounter.team_1 if team_1_wins > team_2_wins
+    return @encounter.team_2 if team_2_wins > team_1_wins
+    return @encounter.team_1 if team_1_ippons > team_2_ippons
+    return @encounter.team_2 if team_2_ippons > team_1_ippons
+
+    # The daihyōsen only breaks a COMPLETE regular-bout tie; while a regular bout
+    # is unresolved the encounter is undecided even if a daihyōsen was scored.
+    complete? ? daihyosen_winner_team : nil
+  end
+
+  def team_1_losses = team_2_wins
+
+  def team_2_losses = team_1_wins
+
+  # Bout-level hikiwake count (not the encounter-level draw outcome). A void
+  # bout (an unfilled position) is never a real draw, so it's excluded even if a
+  # stale draw flag ever lingered on it.
+  def hikiwake = regular.count { |tf| tf.draw && !tf.void? }
+
+  # Anchored on the lineup-submission flags (not bout presence): an empty
+  # encounter is NOT a draw, and a void trailing bout does not block completeness.
+  def complete?
+    @encounter.lineup_1_set? && @encounter.lineup_2_set? &&
+      regular.all? { |tf| tf.winner_id.present? || tf.draw || tf.void? }
+  end
+
+  def outcome_for(team)
+    return nil unless complete?
+    return nil unless [@encounter.team_1_id, @encounter.team_2_id].include?(team.id)
+
+    w = winner
+    return :draw if w.nil?
+
+    (w.id == team.id) ? :win : :loss
+  end
+
+  private def regular = @fights.reject(&:daihyosen?)
+
+  private def won_by?(team_fight, slot)
+    team_fight.winner_id.present? &&
+      team_fight.winner_id == team_fight.public_send(:"kenshi_#{slot}_id")
+  end
+
+  private def daihyosen_winner_team
+    decider = @fights.find(&:daihyosen?)
+    return nil unless decider&.winner_id
+
+    won_by?(decider, 1) ? @encounter.team_1 : @encounter.team_2
+  end
+end

--- a/app/services/encounter_team_swap.rb
+++ b/app/services/encounter_team_swap.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# Swaps the occupants of two round-1 slots of a bracket-only elimination
+# bracket — the admin's draw-correction tool. A swap always exchanges two
+# occupied slots (the target team's current slot receives the displaced team),
+# so the bracket can never end up with a duplicated or dropped team. Teams not
+# in the bracket join via a rebuild, never a swap.
+#
+# Rejected unless every impacted encounter — both round-1 encounters plus any
+# round-2 child fed by a bye among them — is pristine: no winner, no lineup,
+# no recorded fight points.
+class EncounterTeamSwap
+  class InvalidSwap < StandardError; end
+
+  def initialize(encounter)
+    @encounter = encounter
+    @category = encounter.team_category
+  end
+
+  # Whether the slot is offerable at all: bracket-only, round 1, occupied,
+  # and this side's impacted encounters pristine. The other side's state is
+  # only known at swap time and is validated there.
+  def swappable?(slot)
+    category.bracket_only? &&
+      encounter.round == 1 &&
+      occupant(slot).present? &&
+      impacted(encounter).all?(&:pristine?)
+  end
+
+  # Teams an occupied slot can swap with: every other round-1 occupant.
+  def candidates(slot)
+    round_one.includes(:team_1, :team_2)
+      .flat_map { |enc| [enc.team_1, enc.team_2] }.compact - [occupant(slot)]
+  end
+
+  def swap(slot, team)
+    raise InvalidSwap, "swaps only apply to bracket-only categories" unless category.bracket_only?
+    raise InvalidSwap, "only round-1 slots can be swapped" unless encounter.round == 1
+    raise InvalidSwap, "invalid slot" unless [1, 2].include?(slot)
+
+    current = occupant(slot)
+    raise InvalidSwap, "this slot has no team to swap" if current.nil?
+    raise InvalidSwap, "#{team.name} already occupies this slot" if team == current
+
+    other_encounter, other_slot = locate(team)
+    raise InvalidSwap, "#{team.name} is already in this encounter" if other_encounter == encounter
+
+    validate_pristine!(other_encounter)
+
+    Encounter.transaction do
+      encounter.assign_team_to_slot(slot, team)
+      other_encounter.assign_team_to_slot(other_slot, current)
+    end
+  end
+
+  private attr_reader :encounter, :category
+
+  private def occupant(slot)
+    encounter.public_send(:"team_#{slot}")
+  end
+
+  private def round_one
+    category.bracket_encounters.where(round: 1)
+  end
+
+  # The true-swap invariant needs the target in exactly one round-1 slot; a
+  # team added after generation (or any drift) is rejected.
+  private def locate(team)
+    matches = round_one.where("team_1_id = :id OR team_2_id = :id", id: team.id).to_a
+    unless matches.size == 1
+      raise InvalidSwap,
+        "#{team.name} does not occupy exactly one bracket slot — rebuild the bracket instead"
+    end
+
+    match = matches.first
+    [match, (match.team_1_id == team.id) ? 1 : 2]
+  end
+
+  private def validate_pristine!(other_encounter)
+    (impacted(encounter) + impacted(other_encounter)).uniq.each do |enc|
+      next if enc.pristine?
+
+      raise InvalidSwap,
+        "encounter #{enc.number} already has recorded results — clear them before swapping"
+    end
+  end
+
+  # A bye's round-2 child slot changes with the bye's occupant, so it is part
+  # of the swap's blast radius.
+  private def impacted(enc)
+    [enc] + (enc.bye? ? enc.children.to_a : [])
+  end
+end

--- a/app/services/pool_encounter_generator.rb
+++ b/app/services/pool_encounter_generator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Creates a team category's pool encounters (sibling of PoolFightGenerator).
+# Pairs come from Pools::CyclicPairing — a single cycle (each team meets its two
+# cycle-neighbours), NOT a full round-robin, matching the individual side.
+# Idempotent: skips pools that already have encounters.
+class PoolEncounterGenerator
+  def initialize(team_category, pool_number: nil)
+    @team_category = team_category
+    @pool_number = pool_number
+  end
+
+  def call
+    team_category.transaction do
+      pools_to_generate.each { |pool| generate_for(pool) }
+    end
+  end
+
+  private attr_reader :team_category, :pool_number
+
+  private def pools_to_generate
+    generated = team_category.encounters.distinct.pluck(:pool_number)
+    candidates = team_category.team_pools
+    candidates = candidates.select { |pool| pool.number == pool_number } if pool_number
+    candidates.reject { |pool| generated.include?(pool.number) }
+  end
+
+  private def generate_for(pool)
+    teams = pool.teams
+    Pools::CyclicPairing.pairs_for(teams.size).each do |low, high|
+      team_1 = teams[low - 1]
+      team_2 = teams[high - 1]
+      next if team_1.blank? || team_2.blank?
+
+      team_category.encounters.create!(pool_number: pool.number, team_1: team_1, team_2: team_2)
+    end
+  end
+end

--- a/app/services/pool_membership_move.rb
+++ b/app/services/pool_membership_move.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+# Moves one participation into a pool of its individual category — the admin's
+# drag-and-drop pool-correction tool, which also adds a late-registering
+# (unpooled) participant to a pool or splits it off into a brand-new pool. A
+# free move: the participant is appended last in the destination, and a real
+# source pool's positions are compacted to close the gap, so pools may end up
+# unequal sizes. An unpooled source (pool_number nil) has no pool to compact or
+# regenerate; a destination no participant holds yet is created fresh.
+#
+# Because pool cyclic fights and the elimination bracket are derived from pool
+# membership and ranks, a move rebuilds them: the affected pools' fights are
+# regenerated, ranks reset, and any bracket cleared. When that would discard
+# real work — a non-pristine pool fight or an existing bracket — the move
+# refuses unless `force` is set, so the caller can confirm first.
+#
+# Individual analog of TeamPoolMove (Participation/Fight instead of
+# Team/Encounter).
+class PoolMembershipMove
+  Result = Data.define(:status, :from_pool, :to_pool, :created_pool, :emptied_pools,
+    :bracket_cleared, :message)
+
+  def initialize(participation:, to_pool_number:, force: false)
+    @participation = participation
+    @category = participation.category
+    # A blank destination un-pools the participant (pool_number -> nil); the
+    # unpooled panel is the drop target for that.
+    @to_pool = to_pool_number.presence&.to_i
+    @from_pool = participation.pool_number
+    @force = force
+  end
+
+  def call
+    return result(:noop) if to_pool == from_pool
+
+    reasons = destructive_reasons
+    return result(:needs_confirmation, message: confirmation_message(reasons)) if reasons.any? && !force
+
+    fights_generated = category.pool_fights.exists?
+    bracket_existed = category.bracket_fights.any?
+    created = to_pool.present? && pool_new?(to_pool)
+
+    category.transaction do
+      move_member!
+      compact_source!
+      wipe_pool_fights!
+      affected_pools.each { |pool_number| regenerate!(pool_number) } if fights_generated
+      reset_ranks!
+      clear_bracket! if bracket_existed
+    end
+
+    result(:ok, created_pool: created, emptied_pools: emptied_pools, bracket_cleared: bracket_existed)
+  end
+
+  private attr_reader :participation, :category, :to_pool, :from_pool, :force
+
+  private def affected_pools
+    [from_pool, to_pool].compact.uniq
+  end
+
+  # The moved member always loses its old pool_rank: a stale rank is meaningless
+  # in its new pool, and would otherwise linger forever when un-pooling — where
+  # reset_ranks! (scoped to the affected pools) never revisits the now
+  # pool_number-nil record. (TeamPoolMove has the same latent gap; fixed here.)
+  private def move_member!
+    participation.update!(pool_number: to_pool, pool_position: next_position, pool_rank: nil)
+  end
+
+  private def next_position
+    return nil if to_pool.nil?
+
+    (max_position(to_pool) || 0) + 1
+  end
+
+  private def compact_source!
+    return if from_pool.nil?
+
+    category.participations.where(pool_number: from_pool).order(:pool_position, :id)
+      .each_with_index { |member, index| member.update!(pool_position: index + 1) }
+  end
+
+  # destroy_all (not delete_all): Fight owns fight_points (dependent: :destroy),
+  # so let the dependent destroys fire and leave no orphan rows.
+  private def wipe_pool_fights!
+    return if affected_pools.empty?
+
+    category.pool_fights.where(pool_number: affected_pools).destroy_all
+  end
+
+  private def regenerate!(pool_number)
+    PoolFightGenerator.new(category, pool_number: pool_number).call
+  end
+
+  # Matches how IndividualCategoryBracketBuilder clears the tree on a force
+  # rebuild.
+  private def clear_bracket!
+    category.bracket_fights.destroy_all
+  end
+
+  private def reset_ranks!
+    category.participations.where(pool_number: affected_pools).update_all(pool_rank: nil)
+  end
+
+  private def destructive_reasons
+    reasons = affected_pools.reject { |pool_number| pool_pristine?(pool_number) }
+      .map { |pool_number| "Pool #{pool_number} has recorded results" }
+    reasons << "a bracket has been generated" if category.bracket_fights.any?
+    reasons
+  end
+
+  private def pool_pristine?(pool_number)
+    pool_fights(pool_number).all?(&:pristine?)
+  end
+
+  private def pool_fights(pool_number)
+    category.pool_fights.where(pool_number: pool_number).includes(:fight_points).to_a
+  end
+
+  private def pool_new?(pool_number)
+    !category.participations.exists?(pool_number: pool_number)
+  end
+
+  private def max_position(pool_number)
+    category.participations.where(pool_number: pool_number).maximum(:pool_position)
+  end
+
+  private def emptied_pools
+    return [] if from_pool.nil?
+
+    category.participations.exists?(pool_number: from_pool) ? [] : [from_pool]
+  end
+
+  private def confirmation_message(reasons)
+    "#{reasons.join(", ")} — moving this participant will rebuild the affected pools. Move anyway?"
+  end
+
+  private def result(status, created_pool: false, emptied_pools: [], bracket_cleared: false, message: nil)
+    Result.new(status:, from_pool:, to_pool:, created_pool:, emptied_pools:, bracket_cleared:, message:)
+  end
+end

--- a/app/services/pool_standings.rb
+++ b/app/services/pool_standings.rb
@@ -87,8 +87,8 @@ class PoolStandings
     @sanbon_fights ||= fights.reject(&:tiebreaker)
   end
 
-  private def tiebreaker_fights
-    @tiebreaker_fights ||= fights.select(&:tiebreaker)
+  private def kettei_sen_fights
+    @kettei_sen_fights ||= fights.select(&:tiebreaker)
   end
 
   private def fighter_slot(fight, kenshi_id)
@@ -106,7 +106,7 @@ class PoolStandings
   # Returns participation_id => {rank:, tied:}. Every participation gets a
   # distinct sequential rank (so the value can seed a bracket), while `tied`
   # marks the rows whose order within their standings group is arbitrary —
-  # i.e. a genuine tie that no tiebreaker fight resolved.
+  # i.e. a genuine tie that no kettei-sen fight resolved.
   private def assign_ranks(rows)
     sorted = rows.sort_by(&CASCADE_KEY)
     groups = sorted.chunk_while { |a, b| CASCADE_KEY.call(a) == CASCADE_KEY.call(b) }.to_a
@@ -114,7 +114,7 @@ class PoolStandings
     ranking = {}
     cursor = 1
     groups.each do |group|
-      resolved = resolve_pair_with_tiebreaker(group)
+      resolved = resolve_pair_with_kettei_sen(group)
       tied = group.size > 1 && resolved.nil?
       (resolved || group).each do |row|
         ranking[row.participation.id] = {rank: cursor, tied: tied}
@@ -126,20 +126,20 @@ class PoolStandings
   end
 
   # Returns an ordered [winner, loser] array when a 2-way tie is resolved by
-  # a tiebreaker fight with a winner; returns nil otherwise (including for
-  # groups of 3+ and unresolved/draw tiebreakers).
-  private def resolve_pair_with_tiebreaker(group)
+  # a kettei-sen fight with a winner; returns nil otherwise (including for
+  # groups of 3+ and unresolved/draw kettei-sen).
+  private def resolve_pair_with_kettei_sen(group)
     return nil unless group.size == 2
 
     a, b = group
-    fight = tiebreaker_between(a.participation.kenshi_id, b.participation.kenshi_id)
+    fight = kettei_sen_between(a.participation.kenshi_id, b.participation.kenshi_id)
     return nil if fight.nil? || fight.winner_id.blank?
 
     (fight.winner_id == a.participation.kenshi_id) ? [a, b] : [b, a]
   end
 
-  private def tiebreaker_between(kenshi_a_id, kenshi_b_id)
-    tiebreaker_fights.find { |fight|
+  private def kettei_sen_between(kenshi_a_id, kenshi_b_id)
+    kettei_sen_fights.find { |fight|
       ids = [fight.fighter_1_id, fight.fighter_2_id]
       ids.include?(kenshi_a_id) && ids.include?(kenshi_b_id)
     }

--- a/app/services/team_pool_move.rb
+++ b/app/services/team_pool_move.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+# Moves one team into a pool of its team category — the admin's drag-and-drop
+# pool-correction tool, which also adds a late-registering (unpooled) team to a
+# pool or splits it off into a brand-new pool. A free move: the team is appended
+# last in the destination, and a real source pool's positions are compacted to
+# close the gap, so pools may end up unequal sizes. An unpooled source
+# (pool_number nil) has no pool to compact or regenerate; a destination no team
+# yet holds is created fresh.
+#
+# Because pool encounters and the elimination bracket are derived
+# from pool membership and ranks, a move rebuilds them: the affected pools'
+# encounters are regenerated, ranks reset, and any bracket cleared. When that
+# would discard real work — a non-pristine destination/source pool encounter or
+# an existing bracket — the move refuses unless `force` is set, so the caller
+# can confirm first.
+class TeamPoolMove
+  Result = Data.define(:status, :from_pool, :to_pool, :created_pool, :emptied_pools,
+    :bracket_cleared, :message)
+
+  def initialize(team:, to_pool_number:, force: false)
+    @team = team
+    @category = team.team_category
+    # A blank destination un-pools the team (pool_number -> nil); the unpooled
+    # panel is the drop target for that.
+    @to_pool = to_pool_number.presence&.to_i
+    @from_pool = team.pool_number
+    @force = force
+  end
+
+  def call
+    return result(:noop) if to_pool == from_pool
+
+    reasons = destructive_reasons
+    return result(:needs_confirmation, message: confirmation_message(reasons)) if reasons.any? && !force
+
+    # Whether the pool phase has been generated at all (category-wide): a pool
+    # with < 2 teams has no encounters of its own, so a per-pool check would skip
+    # regenerating a destination that only now has enough teams to need
+    # encounters.
+    encounters_generated = category.encounters.where.not(pool_number: nil).exists?
+    bracket_existed = category.bracket_encounters.any?
+    created = to_pool.present? && pool_new?(to_pool)
+
+    category.transaction do
+      move_team!
+      compact_source!
+      wipe_pool_encounters!
+      affected_pools.each { |pool_number| regenerate!(pool_number) } if encounters_generated
+      reset_ranks!
+      clear_bracket! if bracket_existed
+    end
+
+    result(:ok, created_pool: created, emptied_pools: emptied_pools, bracket_cleared: bracket_existed)
+  end
+
+  private attr_reader :team, :category, :to_pool, :from_pool, :force
+
+  # The real pools touched by this move. A nil source (unpooled team) contributes
+  # nothing — and is excluded so a wipe/query never hits bracket or ad-hoc
+  # encounters, which also carry pool_number nil.
+  private def affected_pools
+    [from_pool, to_pool].compact.uniq
+  end
+
+  # The moved team always loses its old pool_rank: a stale rank is meaningless
+  # in its new pool, and would otherwise linger when un-pooling — where
+  # reset_ranks! (scoped to the affected pools) never revisits the now
+  # pool_number-nil team.
+  private def move_team!
+    team.update!(pool_number: to_pool, pool_position: next_position, pool_rank: nil)
+  end
+
+  # Appended last in the destination pool; nil (no position) when un-pooling.
+  private def next_position
+    return nil if to_pool.nil?
+
+    (max_position(to_pool) || 0) + 1
+  end
+
+  # Renumber the source pool's remaining teams to 1..n in their existing order,
+  # so the slot the moved team vacated does not leave a gap. No-op for an
+  # unpooled source.
+  private def compact_source!
+    return if from_pool.nil?
+
+    category.teams.where(pool_number: from_pool).order(:pool_position, :id)
+      .each_with_index { |team, index| team.update!(pool_position: index + 1) }
+  end
+
+  # destroy_all (not delete_all): Encounter owns team_fights (dependent:
+  # :destroy), which own polymorphic fight_points — let the dependent destroys
+  # fire so no orphan rows survive.
+  private def wipe_pool_encounters!
+    return if affected_pools.empty?
+
+    category.encounters.where(pool_number: affected_pools).destroy_all
+  end
+
+  private def regenerate!(pool_number)
+    PoolEncounterGenerator.new(category, pool_number: pool_number).call
+  end
+
+  # Highest round first: bracket encounters reference their parents via
+  # parent_encounter_*_id, so a parent cannot be destroyed while a child still
+  # points at it. (Same order the bracket builder uses on rebuild.)
+  private def clear_bracket!
+    category.bracket_encounters.order(round: :desc).destroy_all
+  end
+
+  private def reset_ranks!
+    category.teams.where(pool_number: affected_pools).update_all(pool_rank: nil)
+  end
+
+  private def destructive_reasons
+    reasons = affected_pools.reject { |pool_number| pool_pristine?(pool_number) }
+      .map { |pool_number| "Pool #{pool_number} has recorded results" }
+    reasons << "a bracket has been generated" if category.bracket_encounters.any?
+    reasons
+  end
+
+  private def pool_pristine?(pool_number)
+    pool_encounters(pool_number).all?(&:pristine?)
+  end
+
+  private def pool_encounters(pool_number)
+    category.encounters.where(pool_number: pool_number)
+      .includes(team_fights: :fight_points).to_a
+  end
+
+  private def pool_new?(pool_number)
+    !category.teams.exists?(pool_number: pool_number)
+  end
+
+  private def max_position(pool_number)
+    category.teams.where(pool_number: pool_number).maximum(:pool_position)
+  end
+
+  private def emptied_pools
+    return [] if from_pool.nil?
+
+    category.teams.exists?(pool_number: from_pool) ? [] : [from_pool]
+  end
+
+  private def confirmation_message(reasons)
+    "#{reasons.join(", ")} — moving this team will rebuild the affected pools. Move anyway?"
+  end
+
+  private def result(status, created_pool: false, emptied_pools: [], bracket_cleared: false, message: nil)
+    Result.new(status:, from_pool:, to_pool:, created_pool:, emptied_pools:, bracket_cleared:, message:)
+  end
+end

--- a/app/services/team_pool_standings.rb
+++ b/app/services/team_pool_standings.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+# Ranks a team pool by the official 8-level cascade (sibling of PoolStandings).
+# Counts only COMPLETE encounters. Residual ties (identical full cascade key) are
+# flagged `tied` and left for the admin to break via pool_rank (rep play-offs are
+# a deferred phase).
+class TeamPoolStandings
+  Row = Data.define(:team, :team_wins, :team_losses, :team_hikiwake,
+    :individual_wins, :individual_losses, :individual_hikiwake,
+    :points_scored, :points_conceded, :rank, :tied)
+
+  # Official 8-level precedence (sorted ascending): "more is better" stats are
+  # negated (wins, draws, individual wins/draws, points scored); "less is better"
+  # stats stay positive (losses, individual losses, points conceded).
+  CASCADE_KEY = ->(r) {
+    [-r.team_wins, r.team_losses, -r.team_hikiwake,
+      -r.individual_wins, r.individual_losses, -r.individual_hikiwake,
+      -r.points_scored, r.points_conceded]
+  }
+
+  def self.for(teams:, encounters:)
+    new(teams: teams, encounters: encounters.to_a).rows
+  end
+
+  def self.persist_ranks!(teams:, encounters:)
+    self.for(teams: teams, encounters: encounters).each do |row|
+      next if row.rank.nil?
+      next if row.team.pool_rank == row.rank
+
+      row.team.update_column(:pool_rank, row.rank) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+
+  def initialize(teams:, encounters:)
+    @teams = teams
+    @encounters = encounters
+  end
+
+  private attr_reader :teams, :encounters
+
+  public def rows
+    base = teams.map { |team| compute_row(team) }
+    return base if no_data?(base)
+
+    ranking = assign_ranks(base)
+    base.map { |row|
+      info = ranking.fetch(row.team.id)
+      row.with(rank: info[:rank], tied: info[:tied])
+    }.sort_by(&:rank)
+  end
+
+  private def compute_row(team)
+    tw = tl = td = iw = il = idr = ps = pc = 0
+    completed_for(team).each do |encounter|
+      result = result_for(encounter)
+      case result.outcome_for(team)
+      when :win then tw += 1
+      when :loss then tl += 1
+      when :draw then td += 1
+      end
+      slot = (encounter.team_1_id == team.id) ? 1 : 2
+      opponent = (slot == 1) ? 2 : 1
+      iw += result.public_send(:"team_#{slot}_wins")
+      il += result.public_send(:"team_#{slot}_losses")
+      idr += result.hikiwake
+      ps += result.public_send(:"team_#{slot}_ippons")
+      pc += result.public_send(:"team_#{opponent}_ippons")
+    end
+    Row.new(team: team, team_wins: tw, team_losses: tl, team_hikiwake: td,
+      individual_wins: iw, individual_losses: il, individual_hikiwake: idr,
+      points_scored: ps, points_conceded: pc, rank: nil, tied: false)
+  end
+
+  private def completed_for(team)
+    encounters.select do |encounter|
+      [encounter.team_1_id, encounter.team_2_id].include?(team.id) && result_for(encounter).complete?
+    end
+  end
+
+  # One EncounterResult per encounter, shared across every team's row. Each
+  # result reads team_fights.to_a once at construction, so caching here avoids
+  # rebuilding it O(teams) times per encounter.
+  private def result_for(encounter)
+    (@results ||= {})[encounter.id] ||= encounter.result
+  end
+
+  private def no_data?(rows)
+    rows.all? { |r| r.team_wins.zero? && r.team_losses.zero? && r.team_hikiwake.zero? }
+  end
+
+  # Distinct sequential ranks; teams sharing an identical full cascade key are
+  # flagged tied (no automated play-off — deferred).
+  private def assign_ranks(rows)
+    sorted = rows.sort_by(&CASCADE_KEY)
+    groups = sorted.chunk_while { |a, b| CASCADE_KEY.call(a) == CASCADE_KEY.call(b) }.to_a
+    ranking = {}
+    cursor = 1
+    groups.each do |group|
+      tied = group.size > 1
+      group.each do |row|
+        ranking[row.team.id] = {rank: cursor, tied: tied}
+        cursor += 1
+      end
+    end
+    ranking
+  end
+end

--- a/app/views/admin/encounters/_editor.html.erb
+++ b/app/views/admin/encounters/_editor.html.erb
@@ -1,0 +1,22 @@
+<%# app/views/admin/encounters/_editor.html.erb %>
+<%= turbo_stream_from [encounter, :panel] %>
+<%= render "admin/encounters/panel", encounter: encounter, admin: true,
+      auto_seed: local_assigns.fetch(:auto_seed, false) %>
+
+<%# Hidden targets for the in-table fighter dropdowns: each side's <select> in the
+    match table carries form="<lineup_form_id>" and name="kenshi_ids[]", so picking
+    a fighter auto-submits that team's whole lineup (see lineup_controller.js). %>
+<% [encounter.team_1, encounter.team_2].compact.each do |team| %>
+  <%= form_with url: admin_team_category_encounter_lineup_path(encounter.team_category, encounter),
+        method: :patch, id: lineup_form_id(encounter, team) do |f| %>
+    <%= f.hidden_field :team_id, value: team.id %>
+  <% end %>
+<% end %>
+
+<%# Hidden target the in-table daihyōsen rep dropdowns associate with via
+    form="<daihyosen_form_id>": picking a rep auto-PATCHes it (see
+    lineup_controller.js). Rendered only once the daihyōsen bout exists. %>
+<% if encounter.team_fights.any?(&:daihyosen?) %>
+  <%= form_with url: admin_team_category_encounter_daihyosen_path(encounter.team_category, encounter),
+        method: :patch, id: daihyosen_form_id(encounter) %>
+<% end %>

--- a/app/views/admin/encounters/_match.html.erb
+++ b/app/views/admin/encounters/_match.html.erb
@@ -1,0 +1,108 @@
+<%# app/views/admin/encounters/_match.html.erb %>
+<% first_scoring_point_id = fight.first_scoring_point&.id # rubocop:disable Lint/UselessAssignment %>
+<% row_id = fight.daihyosen? ? dom_id(fight) : "#{dom_id(encounter)}_position_#{fight.position}" # rubocop:disable Lint/UselessAssignment %>
+<li id="<%= row_id %>" class="pool-match <%= "pool-match--tiebreaker" if fight.daihyosen? %>">
+  <header class="pool-match__header">
+    <span class="pool-match__position">
+      <% if fight.daihyosen? %>
+        Daihyōsen
+      <% else %>
+        <%= TeamPosition.label(fight.position, encounter.team_size) %>
+      <% end %>
+    </span>
+    <%# Result rides the header line to save vertical space. The active Hikiwake
+        toggle already reads as the draw verdict, so only fall through to the
+        textual "hikiwake" when that button isn't shown (a points-tie, or a
+        non-admin viewer). %>
+    <% if admin && fight.hikiwake_eligible? %>
+      <%= button_to fight.draw ? "Hikiwake ✓" : "Hikiwake",
+            admin_team_category_encounter_team_fight_path(encounter.team_category, encounter, fight),
+            method: :patch,
+            params: {team_fight: {draw: !fight.draw}},
+            class: ["pool-match__hikiwake", ("pool-match__hikiwake--active" if fight.draw)],
+            form: {class: "pool-match__hikiwake-form", data: {turbo_stream: true}} %>
+    <% elsif fight.draw %>
+      <span class="pool-match__verdict">hikiwake</span>
+    <% elsif fight.winner %>
+      <span class="pool-match__verdict pool-match__verdict--win"><%= fight.winner.full_name %></span>
+    <% end %>
+  </header>
+
+  <div class="pool-match__sides">
+    <% [1, 2].each do |slot| %>
+      <% kenshi = fight.public_send(:"kenshi_#{slot}") # rubocop:disable Lint/UselessAssignment %>
+      <% side = (slot == 1) ? "fighter_1" : "fighter_2" # rubocop:disable Lint/UselessAssignment %>
+      <% team = teams[slot - 1] # rubocop:disable Lint/UselessAssignment %>
+      <% winner_here = kenshi && fight.winner_id == kenshi.id # rubocop:disable Lint/UselessAssignment %>
+
+      <%= tag.div class: ["pool-match__side", "pool-match__side--#{side}",
+            ("pool-match__side--winner" if winner_here)] do %>
+        <% reorderable = admin && !fight.daihyosen? # rubocop:disable Lint/UselessAssignment %>
+        <%# Any present fighter is draggable, even one whose bout already has
+            points: reordering a scored bout resets it (EncounterLineup clears its
+            points). Blank sides stay valid drop targets. %>
+        <%= tag.div class: "pool-match__row",
+              data: (reorderable ? {
+                reorder_form: lineup_form_id(encounter, team),
+                action: "dragover->lineup#dragOver dragleave->lineup#dragLeave drop->lineup#drop"
+              } : {}) do %>
+          <% if reorderable %>
+            <% if kenshi %>
+              <span class="pool-match__grip" draggable="true" aria-hidden="true" title="Drag to swap fighters"
+                    data-action="dragstart->lineup#dragStart dragend->lineup#dragEnd">⠿</span>
+            <% end %>
+            <%# Fall back to the suggested pick only when this side has no real
+                kenshi yet, so a saved lineup (even a deliberate blank) is shown
+                as-is. The suggestion is unsaved until the admin edits a slot. %>
+            <% selected_id = kenshi&.id || suggestions&.dig(slot)&.[](fight.position - 1) # rubocop:disable Lint/UselessAssignment %>
+            <%= select_tag "kenshi_ids[]",
+                  options_from_collection_for_select(team_kenshis[team.id], :id, :full_name, selected_id),
+                  include_blank: "—",
+                  form: lineup_form_id(encounter, team),
+                  class: "pool-match__select",
+                  data: {action: "change->lineup#submit"} %>
+          <% elsif admin && fight.daihyosen? %>
+            <%= select_tag "kenshi_#{slot}_id",
+                  options_from_collection_for_select(team_kenshis[team.id], :id, :full_name, kenshi&.id),
+                  include_blank: "—",
+                  form: daihyosen_form_id(encounter),
+                  class: "pool-match__select",
+                  data: {action: "change->lineup#submit"} %>
+          <% else %>
+            <span class="pool-match__name"><%= kenshi&.full_name || "—" %></span>
+          <% end %>
+          <ol class="pool-match__points">
+            <% fight.points_for(slot).each do |point| %>
+              <%= tag.li class: ["pool-match__point", "pool-match__point--#{point.kind}",
+                    ("pool-match__point--first" if point.id == first_scoring_point_id)] do %>
+                <%= point.code %>
+                <% if admin %>
+                  <%= button_to "×",
+                        admin_team_category_encounter_team_fight_team_fight_point_path(
+                          encounter.team_category, encounter, fight, point
+                        ),
+                        method: :delete,
+                        class: "pool-match__point-remove",
+                        form: {class: "pool-match__point-remove-form", data: {turbo_stream: true}} %>
+                <% end %>
+              <% end %>
+            <% end %>
+          </ol>
+        <% end %>
+        <% if admin && kenshi %>
+          <div class="pool-match__buttons">
+            <% point_codes.each do |kind, code| %>
+              <%= button_to code,
+                    admin_team_category_encounter_team_fight_team_fight_points_path(
+                      encounter.team_category, encounter, fight
+                    ),
+                    params: {team_fight_point: {fighter_side: side, kind: kind}},
+                    class: ["pool-match__button", "pool-match__button--#{kind}"],
+                    form: {class: "pool-match__button-form", data: {turbo_stream: true}} %>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</li>

--- a/app/views/admin/encounters/_panel.html.erb
+++ b/app/views/admin/encounters/_panel.html.erb
@@ -1,0 +1,3 @@
+<%# app/views/admin/encounters/_panel.html.erb %>
+<%= render EncounterComponent.new(encounter: encounter, admin: admin,
+      auto_seed: local_assigns.fetch(:auto_seed, false)) %>

--- a/app/views/admin/encounters/_summary.html.erb
+++ b/app/views/admin/encounters/_summary.html.erb
@@ -1,0 +1,6 @@
+<%# app/views/admin/encounters/_summary.html.erb %>
+<summary id="<%= dom_id(encounter, :summary) %>" class="encounter-summary">
+  <span class="encounter-summary__team"><%= encounter.team_display_name(1) %></span>
+  <span class="encounter-summary__team encounter-summary__team--right"><%= encounter.team_display_name(2) %></span>
+  <span class="encounter-summary__status"><%= encounter_summary_status(encounter) %></span>
+</summary>

--- a/app/views/admin/encounters/_swap_team.html.erb
+++ b/app/views/admin/encounters/_swap_team.html.erb
@@ -1,0 +1,23 @@
+<%# Draw-correction controls for a bracket-only round-1 encounter: swap a
+    slot's occupant with any other round-1 occupant. data: {turbo: false}
+    forces a full page load back to the category page, where the flash renders
+    above the updated bracket (the form sits inside the encounter panel frame). %>
+<% swap = EncounterTeamSwap.new(encounter) # rubocop:disable Lint/UselessAssignment %>
+<% swappable_slots = [1, 2].select { |slot| swap.swappable?(slot) } # rubocop:disable Lint/UselessAssignment %>
+<% if swappable_slots.any? %>
+  <div class="swap-team">
+    <% swappable_slots.each do |slot| %>
+      <% current = encounter.public_send(:"team_#{slot}") # rubocop:disable Lint/UselessAssignment %>
+      <%= form_with url: admin_team_category_encounter_team_swap_path(encounter.team_category, encounter),
+            method: :post, class: "swap-team__form swap-team__form--slot_#{slot}",
+            data: {turbo: false} do |f| %>
+        <%= f.hidden_field :slot, value: slot %>
+        <%= label_tag "team_id_#{slot}", "Swap #{current.name} with", class: "swap-team__label" %>
+        <%= select_tag :team_id,
+              options_from_collection_for_select(swap.candidates(slot), :id, :name),
+              include_blank: true, id: "team_id_#{slot}", required: true, class: "swap-team__select" %>
+        <%= f.submit "Swap", class: "swap-team__submit" %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/admin/encounters/index.html.erb
+++ b/app/views/admin/encounters/index.html.erb
@@ -1,0 +1,11 @@
+<%# app/views/admin/encounters/index.html.erb %>
+<%= link_to "New encounter", new_admin_team_category_encounter_path(@team_category) %>
+<ul>
+  <% @encounters.each do |encounter| %>
+    <li>
+      <%= link_to "#{encounter.team_display_name(1)} vs #{encounter.team_display_name(2)}",
+            admin_team_category_encounter_path(@team_category, encounter) %>
+      <%= "→ #{encounter.winner.name}" if encounter.winner %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/admin/encounters/new.html.erb
+++ b/app/views/admin/encounters/new.html.erb
@@ -1,0 +1,6 @@
+<%# app/views/admin/encounters/new.html.erb %>
+<%= form_with url: admin_team_category_encounters_path(@team_category), method: :post do |f| %>
+  <%= select_tag "encounter[team_1_id]", options_from_collection_for_select(@team_category.teams, :id, :name) %>
+  <%= select_tag "encounter[team_2_id]", options_from_collection_for_select(@team_category.teams, :id, :name) %>
+  <%= f.submit "Create encounter" %>
+<% end %>

--- a/app/views/admin/encounters/show.html.erb
+++ b/app/views/admin/encounters/show.html.erb
@@ -1,0 +1,17 @@
+<%# app/views/admin/encounters/show.html.erb %>
+<% if @encounter.pool_number.blank? %>
+  <%# Bracket encounter: render inside the panel frame that sits below the tree
+      on the category page, so the bracket stays visible while editing. The
+      encounter_panel controller scrolls this into view on load and the Close
+      button empties the frame client-side. %>
+  <%= turbo_frame_tag dom_id(@encounter.team_category, :encounter_panel) do %>
+    <button type="button" class="encounter__close-panel"
+        data-controller="encounter-panel" data-action="encounter-panel#close">Close</button>
+    <%= render "admin/encounters/editor", encounter: @encounter, auto_seed: true %>
+    <% if @encounter.team_category.bracket_only? && @encounter.round == 1 %>
+      <%= render "admin/encounters/swap_team", encounter: @encounter %>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= render "admin/encounters/editor", encounter: @encounter, auto_seed: true %>
+<% end %>

--- a/app/views/admin/individual_categories/_pools.html.erb
+++ b/app/views/admin/individual_categories/_pools.html.erb
@@ -1,0 +1,12 @@
+<%# The pools container — extracted so the admin show page and the
+    pool-membership controller render it identically. Replacing the whole
+    container (rather than appending a single card) keeps the new-pool stream
+    idempotent: the acting admin is subscribed to the same broadcast stream it
+    renders to, and an append would otherwise be applied twice. %>
+<%= tag.div id: "individual_pools_#{category.id}" do %>
+  <% category.pools.sort_by(&:number).each do |pool| %>
+    <div>
+      <%= render PoolComponent.new(category: category, pool_number: pool.number, admin: true, pool: pool) %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/admin/pool_fights/_match.html.erb
+++ b/app/views/admin/pool_fights/_match.html.erb
@@ -1,10 +1,51 @@
 <% first_scoring_point_id = fight.first_scoring_point&.id # rubocop:disable Lint/UselessAssignment %>
 <li class="pool-match <%= "pool-match--tiebreaker" if fight.tiebreaker %>">
   <header class="pool-match__header">
-    <% if fight.tiebreaker %>
-      Tiebreaker — <%= poster_names[fight.fighter_1_id] %> vs <%= poster_names[fight.fighter_2_id] %>
-    <% else %>
-      Match <%= fight.number %>
+    <span class="pool-match__position">
+      <% if fight.tiebreaker %>
+        Kettei-sen — <%= poster_names[fight.fighter_1_id] %> vs <%= poster_names[fight.fighter_2_id] %>
+      <% else %>
+        Match <%= fight.number %>
+      <% end %>
+    </span>
+    <% if admin %>
+      <div class="pool-match__outcome">
+        <%= button_to "#{poster_names[fight.fighter_1_id]} wins",
+              admin_individual_category_pool_fight_path(category, fight),
+              method: :patch,
+              params: {pool_fight: {winner_id: fight.fighter_1_id}},
+              class: ["pool-match__outcome-btn",
+                ("pool-match__outcome-btn--active" if fight.winner_id == fight.fighter_1_id)],
+              form: {class: "pool-match__outcome-form", data: {turbo: true}} %>
+        <%= button_to "Hikiwake",
+              admin_individual_category_pool_fight_path(category, fight),
+              method: :patch,
+              params: {pool_fight: {draw: true}},
+              class: ["pool-match__outcome-btn",
+                ("pool-match__outcome-btn--active" if fight.draw)],
+              form: {class: "pool-match__outcome-form", data: {turbo: true}} %>
+        <%= button_to "#{poster_names[fight.fighter_2_id]} wins",
+              admin_individual_category_pool_fight_path(category, fight),
+              method: :patch,
+              params: {pool_fight: {winner_id: fight.fighter_2_id}},
+              class: ["pool-match__outcome-btn",
+                ("pool-match__outcome-btn--active" if fight.winner_id == fight.fighter_2_id)],
+              form: {class: "pool-match__outcome-form", data: {turbo: true}} %>
+        <%= button_to "Clear",
+              admin_individual_category_pool_fight_path(category, fight),
+              method: :patch,
+              params: {pool_fight: {winner_id: "", draw: false}},
+              class: "pool-match__outcome-btn pool-match__outcome-btn--clear",
+              form: {class: "pool-match__outcome-form", data: {turbo: true}} %>
+        <% if fight.tiebreaker %>
+          <%= button_to "Remove",
+                admin_individual_category_pool_fight_path(category, fight),
+                method: :delete,
+                data: {confirm: "Delete this kettei-sen?"},
+                class: "pool-match__outcome-btn pool-match__outcome-btn--destroy",
+                form: {class: "pool-match__outcome-form", data: {turbo: true}} %>
+        <% end %>
+      </div>
     <% end %>
   </header>
 
@@ -48,44 +89,4 @@
       <% end %>
     <% end %>
   </div>
-
-  <% if admin %>
-    <div class="pool-match__outcome">
-      <%= button_to "#{poster_names[fight.fighter_1_id]} wins",
-            admin_individual_category_pool_fight_path(category, fight),
-            method: :patch,
-            params: {pool_fight: {winner_id: fight.fighter_1_id}},
-            class: ["pool-match__outcome-btn",
-              ("pool-match__outcome-btn--active" if fight.winner_id == fight.fighter_1_id)],
-            form: {class: "pool-match__outcome-form", data: {turbo: true}} %>
-      <%= button_to "Draw",
-            admin_individual_category_pool_fight_path(category, fight),
-            method: :patch,
-            params: {pool_fight: {draw: true}},
-            class: ["pool-match__outcome-btn",
-              ("pool-match__outcome-btn--active" if fight.draw)],
-            form: {class: "pool-match__outcome-form", data: {turbo: true}} %>
-      <%= button_to "#{poster_names[fight.fighter_2_id]} wins",
-            admin_individual_category_pool_fight_path(category, fight),
-            method: :patch,
-            params: {pool_fight: {winner_id: fight.fighter_2_id}},
-            class: ["pool-match__outcome-btn",
-              ("pool-match__outcome-btn--active" if fight.winner_id == fight.fighter_2_id)],
-            form: {class: "pool-match__outcome-form", data: {turbo: true}} %>
-      <%= button_to "Clear",
-            admin_individual_category_pool_fight_path(category, fight),
-            method: :patch,
-            params: {pool_fight: {winner_id: "", draw: false}},
-            class: "pool-match__outcome-btn pool-match__outcome-btn--clear",
-            form: {class: "pool-match__outcome-form", data: {turbo: true}} %>
-      <% if fight.tiebreaker %>
-        <%= button_to "Remove",
-              admin_individual_category_pool_fight_path(category, fight),
-              method: :delete,
-              data: {confirm: "Delete this tiebreaker?"},
-              class: "pool-match__outcome-btn pool-match__outcome-btn--destroy",
-              form: {class: "pool-match__outcome-form", data: {turbo: true}} %>
-      <% end %>
-    </div>
-  <% end %>
 </li>

--- a/app/views/admin/team_categories/_pool_card.html.erb
+++ b/app/views/admin/team_categories/_pool_card.html.erb
@@ -1,0 +1,3 @@
+<%# Pool card for one pool, used standalone in Turbo Stream replaces (the move
+    response and broadcast) so it matches the admin show page's rendering. %>
+<%= render TeamPoolComponent.new(team_category: team_category, pool_number: pool_number, admin: true) %>

--- a/app/views/admin/team_categories/_pool_standings.html.erb
+++ b/app/views/admin/team_categories/_pool_standings.html.erb
@@ -1,0 +1,70 @@
+<%# app/views/admin/team_categories/_pool_standings.html.erb %>
+<div id="team_pool_standings_<%= team_category.id %>_<%= pool_number %>">
+  <table class="pool-standings">
+    <thead>
+      <tr>
+        <th>Team</th><th>Rank</th>
+        <th>W</th><th>L</th><th>H</th>
+        <th>iW</th><th>iL</th><th>iH</th>
+        <th>Pts+</th><th>Pts−</th>
+        <% if admin %><th><span class="pool-standings__sr-only">Move</span></th><% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <%# Load team_pools once per render: it was previously re-queried on every
+          standings row (the move-select below), turning one card into K+1
+          grouping queries. The per-row move list derives from _pools in memory. %>
+      <% _pools = team_category.team_pools %>
+      <% _pool = _pools.find { |p| p.number == pool_number } %>
+      <% TeamPoolStandings.for(
+           teams: _pool&.teams || [],
+           encounters: team_category.encounters_by_pool_number.fetch(pool_number, [])
+         ).each do |row| %>
+        <tr<% if admin %> data-team-id="<%= row.team.id %>"
+            data-move-url="<%= admin_team_category_pool_membership_path(team_category, row.team) %>"
+            data-from-pool="<%= pool_number %>"<% end %>>
+          <td>
+            <% if admin %>
+              <span class="pool-standings__grip pool-match__grip" draggable="true"
+                    title="Drag to another pool"
+                    data-action="dragstart->pool-membership#dragStart">⠿</span>
+            <% end %>
+            <%= link_to row.team.name, [:admin, row.team] %>
+          </td>
+          <td class="pool-standings__rank">
+            <% if admin %>
+              <%= best_in_place row.team, :pool_rank, as: :input,
+                    url: [:admin, row.team],
+                    class: "best_in_place_short pool-standings__editable", place_holder: "—" %><%= content_tag(:span, "=", class: "pool-standings__tie", title: "Tied — adjust the rank if needed") if row.tied %>
+            <% else %>
+              <%= row.team.pool_rank %><%= "=" if row.tied %>
+            <% end %>
+          </td>
+          <td><%= row.team_wins %></td>
+          <td><%= row.team_losses %></td>
+          <td><%= row.team_hikiwake %></td>
+          <td><%= row.individual_wins %></td>
+          <td><%= row.individual_losses %></td>
+          <td><%= row.individual_hikiwake %></td>
+          <td><%= row.points_scored %></td>
+          <td><%= row.points_conceded %></td>
+          <% if admin %>
+            <td class="pool-standings__move">
+              <% others = _pools.map(&:number) - [pool_number] # rubocop:disable Lint/UselessAssignment %>
+              <% if others.any? %>
+                <select class="pool-standings__move-select"
+                        aria-label="Move <%= row.team.name %> to another pool"
+                        data-action="change->pool-membership#moveViaSelect">
+                  <option value="">Move to…</option>
+                  <% others.each do |n| %>
+                    <option value="<%= n %>">Pool <%= n %></option>
+                  <% end %>
+                </select>
+              <% end %>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin/team_categories/_pool_unpooled.html.erb
+++ b/app/views/admin/team_categories/_pool_unpooled.html.erb
@@ -1,0 +1,3 @@
+<%# Unpooled-teams panel, used standalone in Turbo Stream replaces so it stays
+    in sync as late registrants join pools. %>
+<%= render TeamPoolUnpooledComponent.new(team_category: team_category) %>

--- a/app/views/admin/team_categories/_pools.html.erb
+++ b/app/views/admin/team_categories/_pools.html.erb
@@ -1,0 +1,12 @@
+<%# The pools container — extracted so the admin show page and the
+    pool-membership controller render it identically. Replacing the whole
+    container (rather than appending a single card) keeps the new-pool stream
+    idempotent: the acting admin is subscribed to the same broadcast stream it
+    renders to, and an append would otherwise be applied twice. %>
+<%= tag.div id: "team_pools_#{team_category.id}" do %>
+  <% team_category.team_pools.each do |pool| %>
+    <div>
+      <%= render "admin/team_categories/pool_card", team_category: team_category, pool_number: pool.number %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/team_bracket_trees/_team_bracket_tree.html.erb
+++ b/app/views/team_bracket_trees/_team_bracket_tree.html.erb
@@ -1,0 +1,2 @@
+<%# app/views/team_bracket_trees/_team_bracket_tree.html.erb %>
+<%= render EncounterTreeComponent.new(team_category: team_category, admin: true) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,14 +116,23 @@ en:
     competition_trees:
       generate_bracket:
         notice: Competition tree generated
+    encounters:
+      create:
+        notice: Encounter created.
+      lineups:
+        update:
+          notice: Lineup set.
+      team_swaps:
+        create:
+          notice: Teams swapped.
     fights:
       update:
         notice: Fight updated
     pool_fights:
       create:
-        alert: Pick two different kenshis from this pool for the tiebreaker.
+        alert: Pick two different kenshis from this pool for the kettei-sen.
       destroy:
-        alert: Only tiebreaker fights can be deleted. Use Regenerate to recreate a pool's regular fights.
+        alert: Only kettei-sen fights can be deleted. Use Regenerate to recreate a pool's regular fights.
       generate:
         notice: Pool fights generated
       regenerate:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -120,14 +120,23 @@ fr:
     competition_trees:
       generate_bracket:
         notice: Arbre de compétition généré
+    encounters:
+      create:
+        notice: Rencontre créée.
+      lineups:
+        update:
+          notice: Alignement enregistré.
+      team_swaps:
+        create:
+          notice: Équipes échangées.
     fights:
       update:
         notice: Combat mis à jour
     pool_fights:
       create:
-        alert: Choisissez deux kenshis différents de cette poule pour le barrage.
+        alert: Choisissez deux kenshis différents de cette poule pour le kettei-sen.
       destroy:
-        alert: Seuls les combats de barrage peuvent être supprimés. Utilisez Regénérer pour recréer les combats réguliers d'une poule.
+        alert: Seuls les combats de kettei-sen peuvent être supprimés. Utilisez Regénérer pour recréer les combats réguliers d'une poule.
       generate:
         notice: Combats de poule générés
       regenerate:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,16 @@ Rails.application.routes.draw do
     resources :team_categories do
       resources :documents
       resources :videos
+      resources :pool_memberships, only: :update, module: :team_categories
+      resources :encounters, only: [:index, :new, :create, :show] do
+        resource :lineup, only: :update, module: :encounters
+        resource :team_swap, only: :create, module: :encounters
+        resource :lineup_seed, only: :create, module: :encounters
+        resource :daihyosen, only: :update, module: :encounters
+        resources :team_fights, only: [:update] do
+          resources :team_fight_points, only: [:create, :destroy]
+        end
+      end
     end
     resources :individual_categories do
       post :generate_bracket, on: :member, to: "competition_trees#generate_bracket"
@@ -55,6 +65,7 @@ Rails.application.routes.draw do
       resources :pool_fights, only: [:create, :update, :destroy] do
         resources :fight_points, only: [:create, :destroy]
       end
+      resources :pool_memberships, only: :update, module: :individual_categories
       resources :documents
       resources :videos
     end

--- a/db/migrate/20260607143057_make_fight_points_polymorphic.rb
+++ b/db/migrate/20260607143057_make_fight_points_polymorphic.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class MakeFightPointsPolymorphic < ActiveRecord::Migration[8.1]
+  def up
+    # A renamed column keeps its FK constraint in Postgres; a polymorphic
+    # association cannot carry a single-table FK, so drop it first.
+    remove_foreign_key :fight_points, :fights
+
+    # Drop the old indexes BEFORE the rename. On the PG adapter, rename_column
+    # auto-renames conventionally-named indexes (index_fight_points_on_fight_id*
+    # -> *_scorable_id*), so removing them by their old names afterward raises
+    # "index does not exist" and rolls the migration back.
+    remove_index :fight_points, name: "index_fight_points_on_fight_id_and_position"
+    remove_index :fight_points, name: "index_fight_points_on_fight_id_and_fighter_side"
+    remove_index :fight_points, name: "index_fight_points_on_fight_id"
+
+    add_column :fight_points, :scorable_type, :string
+    rename_column :fight_points, :fight_id, :scorable_id
+    execute("UPDATE fight_points SET scorable_type = 'Fight'")
+    change_column_null :fight_points, :scorable_type, false
+
+    add_index :fight_points, [:scorable_type, :scorable_id]
+    add_index :fight_points, [:scorable_type, :scorable_id, :position], unique: true,
+      name: "index_fight_points_on_scorable_and_position"
+    add_index :fight_points, [:scorable_type, :scorable_id, :fighter_side],
+      name: "index_fight_points_on_scorable_and_side"
+  end
+
+  def down
+    remove_index :fight_points, name: "index_fight_points_on_scorable_and_side"
+    remove_index :fight_points, name: "index_fight_points_on_scorable_and_position"
+    remove_index :fight_points, [:scorable_type, :scorable_id]
+
+    execute("DELETE FROM fight_points WHERE scorable_type <> 'Fight'")
+    rename_column :fight_points, :scorable_id, :fight_id
+    remove_column :fight_points, :scorable_type
+
+    add_index :fight_points, [:fight_id, :position], unique: true,
+      name: "index_fight_points_on_fight_id_and_position"
+    add_index :fight_points, [:fight_id, :fighter_side],
+      name: "index_fight_points_on_fight_id_and_fighter_side"
+    add_index :fight_points, :fight_id, name: "index_fight_points_on_fight_id"
+    add_foreign_key :fight_points, :fights
+  end
+end

--- a/db/migrate/20260627120100_create_team_category_schema.rb
+++ b/db/migrate/20260627120100_create_team_category_schema.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Schema for the team-category feature, consolidated from the incremental
+# migrations originally authored on this branch:
+#   - team size on team_categories, backed by a CHECK constraint
+#   - encounters (pool round-robin + elimination bracket in one table)
+#   - team_fights (the individual bouts within an encounter)
+#   - pool columns on teams
+#
+# Encounters reference teams via team_1_id / team_2_id / winner_id. Deleting a
+# team mid-tournament (or the TeamCategory cascade destroying teams before
+# encounters) would otherwise raise a raw FK violation; on_delete: :nullify
+# blanks the slot instead so the encounter falls back to "to be decided".
+class CreateTeamCategorySchema < ActiveRecord::Migration[8.1]
+  def change
+    add_column :team_categories, :team_size, :integer, default: 5, null: false
+    add_check_constraint :team_categories, "team_size IN (3, 5)",
+      name: "team_categories_team_size_check"
+
+    create_table :encounters do |t|
+      t.references :team_category, null: false, foreign_key: true
+      # Round-1 bracket slots and unscored pool rows may have no team yet.
+      t.references :team_1, foreign_key: {to_table: :teams, on_delete: :nullify}
+      t.references :team_2, foreign_key: {to_table: :teams, on_delete: :nullify}
+      t.references :winner, foreign_key: {to_table: :teams, on_delete: :nullify}
+      # Track which sides have handed in a lineup. A position with one empty
+      # side is only a forfeit once BOTH sides are submitted.
+      t.boolean :lineup_1_set, null: false, default: false
+      t.boolean :lineup_2_set, null: false, default: false
+      # Pool play.
+      t.integer :pool_number
+      # Elimination bracket.
+      t.integer :round
+      t.integer :position
+      t.integer :number
+      t.integer :team_1_pool_number
+      t.integer :team_1_pool_rank
+      t.integer :team_2_pool_number
+      t.integer :team_2_pool_rank
+      t.references :parent_encounter_1, foreign_key: {to_table: :encounters}
+      t.references :parent_encounter_2, foreign_key: {to_table: :encounters}
+      # Persisted so recompute_winner! can skip a full pool re-rank while an
+      # encounter is (and stays) incomplete.
+      t.boolean :completed, null: false, default: false
+      t.timestamps
+    end
+    add_index :encounters, [:team_category_id, :pool_number]
+    add_index :encounters, [:team_category_id, :number],
+      unique: true, where: "pool_number IS NULL",
+      name: "index_encounters_on_category_and_number_bracket"
+    # Bracket-only: pool encounters carry no round/position, so scope the index
+    # to bracket rows rather than relying on Postgres NULL-distinct semantics.
+    add_index :encounters, [:team_category_id, :round, :position],
+      unique: true, where: "pool_number IS NULL",
+      name: "index_encounters_on_category_and_round_and_position"
+
+    create_table :team_fights do |t|
+      t.references :encounter, null: false, foreign_key: true
+      t.references :kenshi_1, foreign_key: {to_table: :kenshis}
+      t.references :kenshi_2, foreign_key: {to_table: :kenshis}
+      t.references :winner, foreign_key: {to_table: :kenshis}
+      t.integer :position, null: false
+      t.boolean :draw, null: false, default: false
+      t.boolean :daihyosen, null: false, default: false
+      t.timestamps
+    end
+    add_index :team_fights, [:encounter_id, :position], unique: true
+
+    add_column :teams, :pool_number, :integer
+    add_column :teams, :pool_position, :integer
+    add_column :teams, :pool_rank, :integer
+    add_column :teams, :seed, :integer
+    add_index :teams, [:team_category_id, :pool_number]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_14_154525) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_27_120100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_catalog.plpgsql"
@@ -104,6 +104,37 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_154525) do
     t.index ["name", "category_type", "category_id"], name: "index_documents_on_name_and_category_type_and_category_id", unique: true
   end
 
+  create_table "encounters", force: :cascade do |t|
+    t.boolean "completed", default: false, null: false
+    t.datetime "created_at", null: false
+    t.boolean "lineup_1_set", default: false, null: false
+    t.boolean "lineup_2_set", default: false, null: false
+    t.integer "number"
+    t.bigint "parent_encounter_1_id"
+    t.bigint "parent_encounter_2_id"
+    t.integer "pool_number"
+    t.integer "position"
+    t.integer "round"
+    t.bigint "team_1_id"
+    t.integer "team_1_pool_number"
+    t.integer "team_1_pool_rank"
+    t.bigint "team_2_id"
+    t.integer "team_2_pool_number"
+    t.integer "team_2_pool_rank"
+    t.bigint "team_category_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "winner_id"
+    t.index ["parent_encounter_1_id"], name: "index_encounters_on_parent_encounter_1_id"
+    t.index ["parent_encounter_2_id"], name: "index_encounters_on_parent_encounter_2_id"
+    t.index ["team_1_id"], name: "index_encounters_on_team_1_id"
+    t.index ["team_2_id"], name: "index_encounters_on_team_2_id"
+    t.index ["team_category_id", "number"], name: "index_encounters_on_category_and_number_bracket", unique: true, where: "(pool_number IS NULL)"
+    t.index ["team_category_id", "pool_number"], name: "index_encounters_on_team_category_id_and_pool_number"
+    t.index ["team_category_id", "round", "position"], name: "index_encounters_on_category_and_round_and_position", unique: true, where: "(pool_number IS NULL)"
+    t.index ["team_category_id"], name: "index_encounters_on_team_category_id"
+    t.index ["winner_id"], name: "index_encounters_on_winner_id"
+  end
+
   create_table "events", id: :serial, force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.integer "cup_id", null: false
@@ -118,14 +149,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_154525) do
 
   create_table "fight_points", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.bigint "fight_id", null: false
     t.string "fighter_side", null: false
     t.string "kind", null: false
     t.integer "position", null: false
+    t.bigint "scorable_id", null: false
+    t.string "scorable_type", null: false
     t.datetime "updated_at", null: false
-    t.index ["fight_id", "fighter_side"], name: "index_fight_points_on_fight_id_and_fighter_side"
-    t.index ["fight_id", "position"], name: "index_fight_points_on_fight_id_and_position", unique: true
-    t.index ["fight_id"], name: "index_fight_points_on_fight_id"
+    t.index ["scorable_type", "scorable_id", "fighter_side"], name: "index_fight_points_on_scorable_and_side"
+    t.index ["scorable_type", "scorable_id", "position"], name: "index_fight_points_on_scorable_and_position", unique: true
+    t.index ["scorable_type", "scorable_id"], name: "index_fight_points_on_scorable_type_and_scorable_id"
   end
 
   create_table "fights", id: :serial, force: :cascade do |t|
@@ -298,19 +330,43 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_154525) do
     t.string "name", limit: 255, null: false
     t.integer "out_of_pool"
     t.integer "pool_size"
+    t.integer "team_size", default: 5, null: false
     t.datetime "updated_at", precision: nil
     t.index ["cup_id", "name"], name: "index_team_categories_on_cup_id_and_name", unique: true
     t.index ["cup_id"], name: "index_team_categories_on_cup_id"
+    t.check_constraint "team_size = ANY (ARRAY[3, 5])", name: "team_categories_team_size_check"
+  end
+
+  create_table "team_fights", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "daihyosen", default: false, null: false
+    t.boolean "draw", default: false, null: false
+    t.bigint "encounter_id", null: false
+    t.bigint "kenshi_1_id"
+    t.bigint "kenshi_2_id"
+    t.integer "position", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "winner_id"
+    t.index ["encounter_id", "position"], name: "index_team_fights_on_encounter_id_and_position", unique: true
+    t.index ["encounter_id"], name: "index_team_fights_on_encounter_id"
+    t.index ["kenshi_1_id"], name: "index_team_fights_on_kenshi_1_id"
+    t.index ["kenshi_2_id"], name: "index_team_fights_on_kenshi_2_id"
+    t.index ["winner_id"], name: "index_team_fights_on_winner_id"
   end
 
   create_table "teams", id: :serial, force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.string "name", limit: 255, null: false
+    t.integer "pool_number"
+    t.integer "pool_position"
+    t.integer "pool_rank"
     t.integer "rank"
+    t.integer "seed"
     t.integer "team_category_id", null: false
     t.datetime "updated_at", precision: nil
     t.index ["rank"], name: "index_teams_on_rank"
     t.index ["team_category_id", "name"], name: "index_teams_on_team_category_id_and_name", unique: true
+    t.index ["team_category_id", "pool_number"], name: "index_teams_on_team_category_id_and_pool_number"
     t.index ["team_category_id"], name: "index_teams_on_team_category_id"
   end
 
@@ -363,8 +419,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_154525) do
   add_foreign_key "cups", "products", column: "product_individual_adult_id"
   add_foreign_key "cups", "products", column: "product_individual_junior_id"
   add_foreign_key "cups", "products", column: "product_team_id"
+  add_foreign_key "encounters", "encounters", column: "parent_encounter_1_id"
+  add_foreign_key "encounters", "encounters", column: "parent_encounter_2_id"
+  add_foreign_key "encounters", "team_categories"
+  add_foreign_key "encounters", "teams", column: "team_1_id", on_delete: :nullify
+  add_foreign_key "encounters", "teams", column: "team_2_id", on_delete: :nullify
+  add_foreign_key "encounters", "teams", column: "winner_id", on_delete: :nullify
   add_foreign_key "events", "cups"
-  add_foreign_key "fight_points", "fights"
   add_foreign_key "headlines", "cups"
   add_foreign_key "individual_categories", "cups"
   add_foreign_key "kenshis", "clubs"
@@ -378,6 +439,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_154525) do
   add_foreign_key "purchases", "kenshis"
   add_foreign_key "purchases", "products"
   add_foreign_key "team_categories", "cups"
+  add_foreign_key "team_fights", "encounters"
+  add_foreign_key "team_fights", "kenshis", column: "kenshi_1_id"
+  add_foreign_key "team_fights", "kenshis", column: "kenshi_2_id"
+  add_foreign_key "team_fights", "kenshis", column: "winner_id"
   add_foreign_key "teams", "team_categories"
   add_foreign_key "users", "clubs"
 end

--- a/spec/components/competition_tree_component_spec.rb
+++ b/spec/components/competition_tree_component_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe CompetitionTreeComponent, type: :component do
   end
 
   it "lists each existing point with a remove button in admin mode" do
-    point = create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men")
+    point = create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
 
     render_inline(described_class.new(category: category.reload, admin: true))
 
@@ -140,9 +140,9 @@ RSpec.describe CompetitionTreeComponent, type: :component do
   end
 
   it "shows each fighter's points as code chips next to their name on the card" do
-    create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men")
-    create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "kote")
-    create(:fight_point, fight: fight, fighter_side: "fighter_2", kind: "hansoku")
+    create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
+    create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "kote")
+    create(:fight_point, scorable: fight, fighter_side: "fighter_2", kind: "hansoku")
 
     render_inline(described_class.new(category: category.reload))
 

--- a/spec/components/encounter_component_spec.rb
+++ b/spec/components/encounter_component_spec.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EncounterComponent, type: :component do
+  let(:tc) { create(:team_category, team_size: 3) }
+  let(:t1) { create(:team, team_category: tc) }
+  let(:t2) { create(:team, team_category: tc) }
+  let(:encounter) { create(:encounter, team_category: tc, team_1: t1, team_2: t2) }
+
+  it "renders the team names and a live tally" do
+    render_inline(described_class.new(encounter: encounter))
+
+    expect(page).to have_text(t1.name)
+    expect(page).to have_text(t2.name)
+    expect(page).to have_text("wins 0–0")
+  end
+
+  it "shows the derived winner when one team leads" do
+    a = create(:kenshi, cup: tc.cup)
+    b = create(:kenshi, cup: tc.cup)
+    tf = create(:team_fight, encounter: encounter, kenshi_1: a, kenshi_2: b)
+    create(:fight_point, scorable: tf, fighter_side: "fighter_1", kind: "men")
+
+    render_inline(described_class.new(encounter: encounter.reload))
+
+    expect(page).to have_text("Winner: #{t1.name}")
+  end
+
+  it "shows the tie banner only once the encounter is complete and level" do
+    a = roster(t1)
+    b = roster(t2)
+    EncounterLineup.new(encounter).assign(t1, a.map(&:id))
+    EncounterLineup.new(encounter).assign(t2, b.map(&:id))
+
+    # Lineups set but bouts unresolved -> not complete -> no banner yet.
+    render_inline(described_class.new(encounter: encounter.reload))
+    expect(page).to have_no_text("Tied")
+
+    # Mark every bout hikiwake -> complete and level -> banner.
+    encounter.team_fights.each { |tf| tf.update!(draw: true) }
+    render_inline(described_class.new(encounter: encounter.reload))
+    expect(page).to have_text("Tied")
+  end
+
+  it "does not show the tie/daihyosen banner for a pool encounter" do
+    encounter.update!(pool_number: 1)
+    a = roster(t1)
+    b = roster(t2)
+    EncounterLineup.new(encounter).assign(t1, a.map(&:id))
+    EncounterLineup.new(encounter).assign(t2, b.map(&:id))
+
+    render_inline(described_class.new(encounter: encounter.reload))
+
+    expect(page).not_to have_text("Tied")
+  end
+
+  describe "lineup prefill suggestions" do
+    it "pre-selects an unset side's dropdowns with the team's previous order" do
+      roster = roster(t1)
+      roster(t2)
+      order = [roster[2], roster[0], roster[1]]
+      previous = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+      EncounterLineup.new(previous).assign(t1, order.map(&:id))
+
+      fresh = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+      render_inline(described_class.new(encounter: fresh, admin: true, auto_seed: true))
+
+      pos1 = page.find("#encounter_#{fresh.id}_position_1 .pool-match__side--fighter_1 select")
+      expect(pos1.find("option[selected]").text).to eq order.first.full_name
+    end
+
+    it "does not override a side whose lineup is already set, blanks included" do
+      roster = roster(t1)
+      roster(t2)
+      previous = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+      EncounterLineup.new(previous).assign(t1, roster.map(&:id))
+
+      fresh = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+      # This encounter's own lineup sets position 2 to a deliberate forfeit.
+      EncounterLineup.new(fresh).assign(t1, [roster[0].id, nil, roster[2].id])
+      render_inline(described_class.new(encounter: fresh.reload, admin: true, auto_seed: true))
+
+      pos2 = page.find("#encounter_#{fresh.id}_position_2 .pool-match__side--fighter_1 select")
+      expect(pos2).to have_no_css("option[selected]") # stays the blank "—"
+    end
+  end
+
+  describe "auto-seed on open" do
+    it "emits a seed URL for a fresh, unset side when opened as an editor" do
+      roster(t1)
+      roster(t2)
+      fresh = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+
+      render_inline(described_class.new(encounter: fresh, admin: true, auto_seed: true))
+
+      expect(page).to have_css(".encounter[data-lineup-seed-url-value]")
+    end
+
+    it "does not emit a seed URL when auto_seed is off" do
+      roster(t1)
+      roster(t2)
+      fresh = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+
+      render_inline(described_class.new(encounter: fresh, admin: true, auto_seed: false))
+
+      expect(page).to have_no_css(".encounter[data-lineup-seed-url-value]")
+    end
+
+    it "does not emit a seed URL once the lineup is already populated" do
+      a = roster(t1)
+      b = roster(t2)
+      fresh = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+      EncounterLineup.new(fresh).seed(t1, a.map(&:id)) # populated, not confirmed
+      EncounterLineup.new(fresh).assign(t2, b.map(&:id))
+
+      render_inline(described_class.new(encounter: fresh.reload, admin: true, auto_seed: true))
+
+      expect(page).to have_no_css(".encounter[data-lineup-seed-url-value]")
+    end
+  end
+
+  describe "drag-to-reorder handles" do
+    it "gives each filled admin fighter card a drag handle and a same-team drop zone" do
+      a = roster(t1)
+      EncounterLineup.new(encounter).assign(t1, a.map(&:id))
+
+      render_inline(described_class.new(encounter: encounter.reload, admin: true))
+
+      # One drop-zone row per fighter_1 slot, all tagged with that team's form id.
+      expect(page).to have_css(
+        ".pool-match__side--fighter_1 .pool-match__row[data-reorder-form]",
+        count: tc.team_size
+      )
+      expect(page).to have_css(
+        ".pool-match__side--fighter_1 .pool-match__grip[draggable='true']",
+        count: tc.team_size
+      )
+    end
+
+    it "still shows the drag handle on a scored bout (reordering resets it)" do
+      a = roster(t1)
+      b = roster(t2)
+      EncounterLineup.new(encounter).assign(t1, a.map(&:id))
+      EncounterLineup.new(encounter).assign(t2, b.map(&:id))
+      scored = encounter.team_fights.order(:position).first
+      create(:fight_point, scorable: scored, fighter_side: "fighter_1", kind: "men")
+
+      render_inline(described_class.new(encounter: encounter.reload, admin: true))
+
+      scored_row = "#encounter_#{encounter.id}_position_1 .pool-match__side--fighter_1"
+      expect(page).to have_css("#{scored_row} .pool-match__grip")
+      expect(page).to have_no_css("#{scored_row} .pool-match__row[data-reorder-locked]")
+    end
+
+    it "shows no drag handles to non-admins" do
+      a = roster(t1)
+      EncounterLineup.new(encounter).assign(t1, a.map(&:id))
+
+      render_inline(described_class.new(encounter: encounter.reload, admin: false))
+
+      expect(page).to have_no_css(".pool-match__grip")
+    end
+  end
+
+  describe "unresolved bracket slots" do
+    let(:a) { create(:team, team_category: tc) }
+
+    it "renders a placeholder instead of crashing when a side is unresolved" do
+      parent = create(:encounter, team_category: tc, team_1: a, team_2: create(:team, team_category: tc))
+      encounter = create(:encounter, team_category: tc, team_1: nil, team_2: nil,
+        round: 2, position: 1, parent_encounter_1: parent)
+
+      render_inline(described_class.new(encounter: encounter, admin: true))
+
+      expect(page).to have_text("To be decided")
+    end
+  end
+
+  describe "hikiwake toggle" do
+    it "shows the toggle on a confirmed, both-present, no-points bout" do
+      a = roster(t1)
+      b = roster(t2)
+      EncounterLineup.new(encounter).assign(t1, a.map(&:id))
+      EncounterLineup.new(encounter).assign(t2, b.map(&:id))
+
+      render_inline(described_class.new(encounter: encounter.reload, admin: true))
+
+      expect(page).to have_button("Hikiwake", minimum: 1)
+    end
+
+    it "does not show the toggle while a lineup is unconfirmed" do
+      a = roster(t1)
+      roster(t2)
+      # #seed persists fighters without confirming — the predicate must still gate.
+      EncounterLineup.new(encounter).seed(t1, a.map(&:id))
+
+      render_inline(described_class.new(encounter: encounter.reload, admin: true))
+
+      expect(page).to have_no_button("Hikiwake")
+    end
+  end
+
+  def roster(team)
+    Array.new(tc.team_size) do
+      create(:kenshi, cup: tc.cup).tap { |k| create(:participation, category: tc, team: team, kenshi: k) }
+    end
+  end
+
+  it "renders the daihyosen reps as editable roster dropdowns" do
+    a = create(:kenshi, cup: tc.cup)
+    b = create(:kenshi, cup: tc.cup)
+    create(:participation, category: tc, team: t1, kenshi: a)
+    create(:participation, category: tc, team: t2, kenshi: b)
+    create(:team_fight, encounter: encounter, daihyosen: true,
+      position: tc.team_size + 1, kenshi_1: a, kenshi_2: b)
+
+    render_inline(described_class.new(encounter: encounter.reload, admin: true))
+
+    expect(page).to have_css("select[name='kenshi_1_id']")
+    expect(page).to have_css("select[name='kenshi_2_id']")
+  end
+end

--- a/spec/components/encounter_tree_component_spec.rb
+++ b/spec/components/encounter_tree_component_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EncounterTreeComponent, type: :component do
+  let(:tc) { create(:team_category, pool_size: 3, out_of_pool: 1) }
+
+  def ranked_team(pool_number)
+    create(:team, team_category: tc, pool_number: pool_number, pool_rank: 1)
+  end
+
+  it "renders a card per resolved round-1 encounter with team names" do
+    a = ranked_team(1)
+    b = ranked_team(2)
+    TeamCategoryBracketBuilder.new(tc).call
+
+    render_inline(described_class.new(team_category: tc, admin: true))
+
+    expect(page).to have_text(a.name)
+    expect(page).to have_text(b.name)
+    # The link targets the encounter panel frame below the tree (no _top) so the
+    # editor opens beneath the bracket; the encounter show renders that frame.
+    expect(page).to have_link("Encounter 1")
+    expect(page).to have_no_css('a[data-turbo-frame="_top"]')
+  end
+
+  it "targets the encounter panel frame so the bracket stays visible on click" do
+    ranked_team(1)
+    ranked_team(2)
+    TeamCategoryBracketBuilder.new(tc).call
+
+    render_inline(described_class.new(team_category: tc, admin: true))
+
+    expect(page).to have_css(
+      %(a[data-turbo-frame="encounter_panel_team_category_#{tc.id}"]),
+      text: "Encounter 1"
+    )
+  end
+
+  it "shows a 'Waiting for encounter N' placeholder for an unresolved round-2 slot" do
+    ranked_team(1)
+    ranked_team(2)
+    ranked_team(3)
+    ranked_team(4)
+    TeamCategoryBracketBuilder.new(tc).call
+
+    render_inline(described_class.new(team_category: tc, admin: true))
+
+    # The final's slots forecast their undecided round-1 parents (mirrors the
+    # individual tree's "Waiting for fight N").
+    expect(page).to have_text("Waiting for encounter")
+  end
+
+  it "renders nothing meaningful when there is no bracket" do
+    render_inline(described_class.new(team_category: tc, admin: true))
+    expect(page).to have_css(".competition-tree")
+  end
+
+  it "ignores an ad-hoc encounter that has no round (does not crash on layout)" do
+    a = create(:team, team_category: tc)
+    b = create(:team, team_category: tc)
+    create(:encounter, team_category: tc, team_1: a, team_2: b) # pool_number nil, round nil
+
+    expect {
+      render_inline(described_class.new(team_category: tc, admin: true))
+    }.not_to raise_error
+    expect(page).to have_text("No bracket yet")
+  end
+
+  it "shows a seeded round-1 slot's label once when its team is unresolved" do
+    # out_of_pool 2 but only rank-1 teams exist, so the rank-2 slots carry a seed
+    # (pool.rank) with no resolved team — the label must render once (prefix), not
+    # be duplicated as the slot name.
+    tc.update!(out_of_pool: 2)
+    create(:team, team_category: tc, pool_number: 1, pool_rank: 1)
+    create(:team, team_category: tc, pool_number: 2, pool_rank: 1)
+    TeamCategoryBracketBuilder.new(tc).call
+
+    render_inline(described_class.new(team_category: tc, admin: true))
+
+    expect(page.text.scan("1.2").size).to eq 1
+    expect(page.text.scan("2.2").size).to eq 1
+  end
+end

--- a/spec/components/individual_pool_unpooled_component_spec.rb
+++ b/spec/components/individual_pool_unpooled_component_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IndividualPoolUnpooledComponent, type: :component do
+  let(:cup) { create(:cup) }
+  let(:category) { create(:individual_category, cup: cup, pool_size: 3) }
+
+  def member(pool: nil, position: nil)
+    create(:participation, category: category, kenshi: create(:kenshi, cup: cup),
+      pool_number: pool, pool_position: position)
+  end
+
+  it "lists only unpooled members, draggable, with an add-to select" do
+    member(pool: 1, position: 1)
+    late = member
+
+    render_inline(described_class.new(category: category))
+
+    expect(page).to have_text("Unpooled participants")
+    expect(page).to have_css("li.pool-unpooled__team[data-participation-id='#{late.id}']")
+    expect(page).to have_css("li[data-participation-id='#{late.id}'] .pool-unpooled__grip[draggable='true']")
+  end
+
+  it "offers each existing pool plus a New pool option in the select" do
+    member(pool: 1, position: 1)
+    member(pool: 2, position: 1)
+    member
+
+    render_inline(described_class.new(category: category))
+
+    expect(page).to have_css("option[value='1']", text: "Pool 1")
+    expect(page).to have_css("option[value='2']", text: "Pool 2")
+    expect(page).to have_css("option[value='3']", text: "New pool (Pool 3)")
+  end
+
+  it "stays visible as a drop zone even when no members are unpooled" do
+    member(pool: 1, position: 1)
+
+    render_inline(described_class.new(category: category))
+
+    expect(page).to have_css("#individual_pool_unpooled_#{category.id}.pool-unpooled")
+    expect(page).to have_text("Unpooled participants")
+    expect(page).to have_css("[data-action*='drop->pool-membership#dropUnpool']")
+  end
+end

--- a/spec/components/pool_component_spec.rb
+++ b/spec/components/pool_component_spec.rb
@@ -106,6 +106,49 @@ RSpec.describe PoolComponent, type: :component do
 
     rendered = render_inline(described_class.new(category: category, pool_number: 1, admin: true))
 
-    expect(rendered.to_html).to include("Tiebreaker —")
+    expect(rendered.to_html).to include("Kettei-sen —")
+  end
+
+  describe "drag-and-drop wiring (admin)" do
+    it "makes the card a pool-membership drop target" do
+      add_kenshi(pool: 1, position: 1)
+
+      rendered = render_inline(described_class.new(category: category, pool_number: 1, admin: true))
+
+      expect(rendered.css(".pool-card[data-controller='pool-membership']")).to be_present
+      expect(rendered.to_html).to include("drop->pool-membership#drop")
+    end
+
+    it "marks each standings row draggable with its move URL and source pool" do
+      kenshi = add_kenshi(pool: 1, position: 1)
+      participation = category.participations.find_by(kenshi: kenshi)
+
+      rendered = render_inline(described_class.new(category: category, pool_number: 1, admin: true))
+
+      row = rendered.css("tr[data-participation-id='#{participation.id}']").first
+      expect(row).to be_present
+      expect(row["data-from-pool"]).to eq "1"
+      expect(row["data-move-url"]).to include("/pool_memberships/#{participation.id}")
+      expect(row.css(".pool-standings__grip[draggable='true']")).to be_present
+    end
+
+    it "offers a Move-to select listing the other pools" do
+      add_kenshi(pool: 1, position: 1)
+      add_kenshi(pool: 2, position: 1)
+
+      rendered = render_inline(described_class.new(category: category, pool_number: 1, admin: true))
+
+      expect(rendered.css("select.pool-standings__move-select")).to be_present
+      expect(rendered.to_html).to include("Pool 2")
+    end
+
+    it "renders no drag wiring for the public view" do
+      add_kenshi(pool: 1, position: 1)
+
+      rendered = render_inline(described_class.new(category: category, pool_number: 1, admin: false))
+
+      expect(rendered.css("[data-controller='pool-membership']")).to be_empty
+      expect(rendered.css(".pool-standings__grip")).to be_empty
+    end
   end
 end

--- a/spec/components/team_pool_component_spec.rb
+++ b/spec/components/team_pool_component_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeamPoolComponent, type: :component do
+  it "renders a standings row per team with the pool number" do
+    tc = create(:team_category, pool_size: 3)
+    t1 = create(:team, team_category: tc, pool_number: 1, pool_position: 1)
+    t2 = create(:team, team_category: tc, pool_number: 1, pool_position: 2)
+
+    render_inline(described_class.new(team_category: tc, pool_number: 1, admin: false))
+
+    expect(page).to have_text("Pool 1")
+    expect(page).to have_text(t1.name)
+    expect(page).to have_text(t2.name)
+  end
+
+  it "wraps the standings in a broadcast-targetable sub-panel" do
+    tc = create(:team_category, pool_size: 3)
+    create(:team, team_category: tc, pool_number: 1, pool_position: 1)
+
+    render_inline(described_class.new(team_category: tc, pool_number: 1, admin: true))
+
+    expect(page).to have_css("#team_pool_standings_#{tc.id}_1 table.pool-standings")
+  end
+
+  describe "inline encounter editors" do
+    let(:tc) { create(:team_category, team_size: 3, pool_size: 3) }
+    let(:t1) { create(:team, team_category: tc, pool_number: 1, pool_position: 1) }
+    let(:t2) { create(:team, team_category: tc, pool_number: 1, pool_position: 2) }
+    let!(:encounter) { create(:encounter, team_category: tc, pool_number: 1, team_1: t1, team_2: t2) }
+
+    it "renders a collapsible editor per encounter for admins" do
+      render_inline(described_class.new(team_category: tc, pool_number: 1, admin: true))
+
+      expect(page).to have_css("details.pool-encounter summary#summary_encounter_#{encounter.id}")
+      expect(page).to have_text("#{t1.name} vs #{t2.name}")
+      expect(page).to have_text("not yet scored") # complete?-before-winner: unscored reads "not yet scored"
+      # the embedded editor (lineup/scoring forms) is hidden inside a closed <details>
+      expect(page).to have_css("details.pool-encounter form", visible: false)
+    end
+
+    it "auto-seeds the inline editor so its bouts open pre-filled with fighter names" do
+      [t1, t2].each do |team|
+        create(:participation, category: tc, team: team, kenshi: create(:kenshi, cup: tc.cup))
+      end
+
+      render_inline(described_class.new(team_category: tc, pool_number: 1, admin: true))
+
+      expect(page).to have_css(".encounter[data-lineup-seed-url-value]", visible: false)
+    end
+
+    it "shows a read-only link list (no editor) for non-admins" do
+      render_inline(described_class.new(team_category: tc, pool_number: 1, admin: false))
+
+      expect(page).not_to have_css("details.pool-encounter")
+      expect(page).to have_link("#{t1.name} vs #{t2.name}")
+    end
+  end
+end

--- a/spec/components/team_pool_unpooled_component_spec.rb
+++ b/spec/components/team_pool_unpooled_component_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeamPoolUnpooledComponent, type: :component do
+  let(:cup) { create(:cup) }
+  let(:tc) { create(:team_category, cup: cup, pool_size: 3) }
+
+  it "lists only unpooled teams, draggable, with an add-to select" do
+    create(:team, team_category: tc, pool_number: 1, pool_position: 1)
+    create(:team, team_category: tc, pool_number: 1, pool_position: 2)
+    late = create(:team, team_category: tc, pool_number: nil)
+
+    render_inline(described_class.new(team_category: tc))
+
+    expect(page).to have_text("Unpooled teams")
+    expect(page).to have_css("li.pool-unpooled__team[data-team-id='#{late.id}']")
+    expect(page).to have_css("li[data-team-id='#{late.id}'] .pool-unpooled__grip[draggable='true']")
+    expect(page).to have_text(late.name)
+  end
+
+  it "offers each existing pool plus a New pool option in the select" do
+    create(:team, team_category: tc, pool_number: 1, pool_position: 1)
+    create(:team, team_category: tc, pool_number: 2, pool_position: 1)
+    create(:team, team_category: tc, pool_number: nil)
+
+    render_inline(described_class.new(team_category: tc))
+
+    expect(page).to have_css("option[value='1']", text: "Pool 1")
+    expect(page).to have_css("option[value='2']", text: "Pool 2")
+    expect(page).to have_css("option[value='3']", text: "New pool (Pool 3)") # max(2) + 1
+  end
+
+  it "stays visible as a drop zone even when no teams are unpooled" do
+    create(:team, team_category: tc, pool_number: 1, pool_position: 1)
+
+    render_inline(described_class.new(team_category: tc))
+
+    expect(page).to have_css("#team_pool_unpooled_#{tc.id}.pool-unpooled")
+    expect(page).to have_text("Unpooled teams")
+    expect(page).to have_text("Drag a team here to remove it from its pool.")
+    expect(page).to have_css("[data-action*='drop->pool-membership#dropUnpool']")
+  end
+end

--- a/spec/factories/encounters.rb
+++ b/spec/factories/encounters.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :encounter do
+    team_category
+    team_1 { association :team, team_category: team_category }
+    team_2 { association :team, team_category: team_category }
+  end
+end

--- a/spec/factories/fight_points.rb
+++ b/spec/factories/fight_points.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :fight_point do
-    fight
+    association :scorable, factory: :fight
     fighter_side { "fighter_1" }
     kind { "men" }
   end

--- a/spec/factories/team_fights.rb
+++ b/spec/factories/team_fights.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :team_fight do
+    encounter
+    position do |tf|
+      (tf.encounter.team_fights.maximum(:position) || 0) + 1
+    end
+  end
+end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :team do
-    name { "team_name_" + Faker::Company.name + rand(1000) }
+    name { "team_name_" + Faker::Company.name + rand(1000).to_s }
   end
 end

--- a/spec/models/encounter_spec.rb
+++ b/spec/models/encounter_spec.rb
@@ -1,0 +1,284 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Encounter do
+  let(:tc) { create(:team_category) }
+
+  it "is valid with two distinct teams of the category" do
+    encounter = build(:encounter, team_category: tc,
+      team_1: create(:team, team_category: tc), team_2: create(:team, team_category: tc))
+    expect(encounter).to be_valid
+  end
+
+  it "rejects the same team on both sides" do
+    team = create(:team, team_category: tc)
+    encounter = build(:encounter, team_category: tc, team_1: team, team_2: team)
+    expect(encounter).not_to be_valid
+  end
+
+  it "rejects a team from another category" do
+    foreign = create(:team, team_category: create(:team_category))
+    encounter = build(:encounter, team_category: tc,
+      team_1: create(:team, team_category: tc), team_2: foreign)
+    expect(encounter).not_to be_valid
+  end
+
+  it "nullifies a slot when its team is deleted (instead of raising a FK error)" do
+    team_1 = create(:team, team_category: tc)
+    team_2 = create(:team, team_category: tc)
+    encounter = create(:encounter, team_category: tc, team_1: team_1, team_2: team_2, winner: team_1)
+
+    expect { team_1.destroy! }.not_to raise_error
+
+    expect(encounter.reload.team_1_id).to be_nil
+    expect(encounter.winner_id).to be_nil
+    expect(encounter.team_2_id).to eq team_2.id
+  end
+
+  describe "bracket vs pool team requirements" do
+    it "allows a bracket encounter (pool_number nil) with no teams yet" do
+      encounter = build(:encounter, team_category: tc, team_1: nil, team_2: nil, pool_number: nil)
+      expect(encounter).to be_valid
+    end
+
+    it "requires both teams on a pool encounter" do
+      encounter = build(:encounter, team_category: tc, team_1: nil, team_2: nil, pool_number: 1)
+      expect(encounter).not_to be_valid
+      expect(encounter.errors[:team_1]).to be_present
+    end
+  end
+
+  describe "#recompute_winner!" do
+    let(:t1) { create(:team, team_category: tc) }
+    let(:t2) { create(:team, team_category: tc) }
+    let(:encounter) { create(:encounter, team_category: tc, team_1: t1, team_2: t2) }
+
+    it "persists the winning team derived from its bouts" do
+      a = create(:kenshi, cup: tc.cup)
+      b = create(:kenshi, cup: tc.cup)
+      tf = create(:team_fight, encounter: encounter, kenshi_1: a, kenshi_2: b)
+      create(:fight_point, scorable: tf, fighter_side: "fighter_1", kind: "men")
+
+      expect(encounter.reload.winner).to eq t1 # set via TeamFight after_update_commit
+    end
+  end
+
+  describe "resolution and byes" do
+    let(:a) { create(:team, team_category: tc) }
+    let(:b) { create(:team, team_category: tc) }
+
+    it "resolves a slot from a parent encounter's winner" do
+      parent = create(:encounter, team_category: tc, team_1: a, team_2: b, winner: a)
+      child = create(:encounter, team_category: tc, team_1: nil, team_2: nil,
+        parent_encounter_1: parent)
+      expect(child.resolved_team_1).to eq a
+    end
+
+    it "treats a one-sided round-1 encounter with no parents as a bye" do
+      bye = build(:encounter, team_category: tc, team_1: a, team_2: nil, round: 1, position: 1)
+      expect(bye.bye?).to be true
+      expect(bye.bye_team).to eq a
+      expect(bye.winner_or_bye).to eq a
+    end
+
+    it "is not a bye when the empty side still has a parent feeding it" do
+      parent = create(:encounter, team_category: tc, team_1: a, team_2: b)
+      enc = build(:encounter, team_category: tc, team_1: a, team_2: nil,
+        parent_encounter_2: parent, round: 2, position: 1)
+      expect(enc.bye?).to be false
+    end
+  end
+
+  describe "pool standings recompute" do
+    let(:pool_tc) { create(:team_category, team_size: 3, pool_size: 3) }
+    let(:t1) { create(:team, team_category: pool_tc, pool_number: 1, pool_position: 1) }
+    let(:t2) { create(:team, team_category: pool_tc, pool_number: 1, pool_position: 2) }
+
+    it "persists pool_rank for the pool's teams when a pool encounter completes" do
+      encounter = create(:encounter, team_category: pool_tc, pool_number: 1, team_1: t1, team_2: t2)
+      # Build the bouts directly (no EncounterLineup membership setup needed here).
+      fights = (1..3).map do |pos|
+        encounter.team_fights.create!(position: pos,
+          kenshi_1: create(:kenshi, cup: pool_tc.cup), kenshi_2: create(:kenshi, cup: pool_tc.cup))
+      end
+      encounter.update!(lineup_1_set: true, lineup_2_set: true)
+      # t1 wins two bouts, the third is a hikiwake -> t1 wins the encounter
+      create(:fight_point, scorable: fights[0], fighter_side: "fighter_1", kind: "men")
+      create(:fight_point, scorable: fights[1], fighter_side: "fighter_1", kind: "men")
+      fights[2].update!(draw: true) # draw change fires the post-commit recompute chain
+
+      expect(t1.reload.pool_rank).to eq 1
+      expect(t2.reload.pool_rank).to eq 2
+    end
+  end
+
+  describe "bracket tree broadcast" do
+    # broadcast_replace_later_to enqueues a Turbo::Streams::ActionBroadcastJob, so
+    # we drive the job and assert on the underlying ActionCable broadcast (mirrors
+    # the Fight competition-tree broadcast spec).
+    it "broadcasts a tree replace when a bracket encounter's winner changes" do
+      a = create(:team, team_category: tc)
+      b = create(:team, team_category: tc)
+      encounter = create(:encounter, team_category: tc, team_1: a, team_2: b, round: 1, position: 1)
+      allow(ActionCable.server).to receive(:broadcast)
+
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+      begin
+        encounter.update!(winner: a)
+      ensure
+        ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false
+      end
+
+      expect(ActionCable.server).to have_received(:broadcast).with(
+        kind_of(String),
+        include("encounter_tree_team_category_#{tc.id}")
+      )
+    end
+
+    it "broadcasts a tree replace when a bracket encounter's team changes" do
+      a = create(:team, team_category: tc)
+      b = create(:team, team_category: tc)
+      encounter = create(:encounter, team_category: tc, team_1: a, team_2: b, round: 1, position: 1)
+      allow(ActionCable.server).to receive(:broadcast)
+
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+      begin
+        encounter.update!(team_2: create(:team, team_category: tc))
+      ensure
+        ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false
+      end
+
+      expect(ActionCable.server).to have_received(:broadcast).with(
+        kind_of(String),
+        include("encounter_tree_team_category_#{tc.id}")
+      )
+    end
+
+    it "does not broadcast the tree for a pool encounter" do
+      a = create(:team, team_category: tc)
+      b = create(:team, team_category: tc)
+      encounter = create(:encounter, team_category: tc, team_1: a, team_2: b, pool_number: 1)
+      ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+
+      encounter.update!(winner: a)
+
+      tree_jobs = ActiveJob::Base.queue_adapter.enqueued_jobs.select { |job|
+        job[:args].to_s.include?("encounter_tree_team_category_")
+      }
+      expect(tree_jobs).to be_empty
+    end
+  end
+
+  describe "bye propagation to children" do
+    let(:category) { create(:team_category, pool_size: nil) }
+    let(:bye) { category.bracket_encounters.where(round: 1).detect(&:bye?) }
+    let(:fight) { category.bracket_encounters.where(round: 1).detect { |e| !e.bye? } }
+    let(:final) { category.bracket_encounters.find_by(round: 2) }
+
+    before do
+      create_list(:team, 3, team_category: category)
+      TeamCategoryBracketBuilder.new(category, random: Random.new(1)).call
+    end
+
+    it "re-seeds the round-2 slot when the bye occupant changes" do
+      replacement = fight.team_1
+      bye.assign_team_to_slot(bye.bye_slot, replacement)
+
+      slot = (final.parent_encounter_1_id == bye.id) ? 1 : 2
+      expect(final.reload.public_send(:"team_#{slot}_id")).to eq replacement.id
+    end
+
+    it "does not touch the child slot when a non-bye encounter's team changes" do
+      outsider = create(:team, team_category: category)
+      slot = (final.parent_encounter_1_id == fight.id) ? 1 : 2
+      fight.assign_team_to_slot(1, outsider)
+
+      expect(final.reload.public_send(:"team_#{slot}_id")).to be_nil
+    end
+  end
+
+  describe "advancement and invalidation" do
+    let(:a) { create(:team, team_category: tc) }
+    let(:b) { create(:team, team_category: tc) }
+    let(:c) { create(:team, team_category: tc) }
+
+    def member(team)
+      k = create(:kenshi, cup: tc.cup)
+      create(:participation, category: tc, team: team, kenshi: k)
+      k
+    end
+
+    it "propagates a winner into the matching child slot" do
+      parent = create(:encounter, team_category: tc, team_1: a, team_2: b)
+      child = create(:encounter, team_category: tc, team_1: nil, team_2: nil,
+        parent_encounter_1: parent)
+
+      parent.update!(winner: a)
+
+      expect(child.reload.team_1_id).to eq a.id
+    end
+
+    it "clears stale points on the side when a slot re-resolves to another team" do
+      child = create(:encounter, team_category: tc, team_1: a, team_2: c)
+      member(a)
+      tf = create(:team_fight, encounter: child, kenshi_1: a.kenshis.first, kenshi_2: c.kenshis.first)
+      create(:fight_point, scorable: tf, fighter_side: "fighter_1", kind: "men")
+      child.update!(lineup_1_set: true)
+
+      child.assign_team_to_slot(1, b)
+
+      tf.reload
+      expect(child.reload.team_1_id).to eq b.id
+      expect(child.lineup_1_set).to be false
+      expect(tf.kenshi_1_id).to be_nil
+      expect(tf.fight_points.where(fighter_side: "fighter_1")).to be_empty
+    end
+
+    it "is a no-op on first fill (nil -> team) and keeps no stale state" do
+      child = create(:encounter, team_category: tc, team_1: nil, team_2: c)
+      child.assign_team_to_slot(1, a)
+      expect(child.reload.team_1_id).to eq a.id
+      expect(child.team_fights).to be_empty
+    end
+
+    it "clears a descendant's recorded winner when an upstream result changes it out" do
+      parent = create(:encounter, team_category: tc, team_1: a, team_2: b, winner: a)
+      child = create(:encounter, team_category: tc, team_1: nil, team_2: c,
+        parent_encounter_1: parent)
+      child.assign_team_to_slot(1, a)
+      child.update!(winner: a)
+
+      parent.update!(winner: b) # a no longer advances
+
+      expect(child.reload.winner_id).to be_nil
+      expect(child.team_1_id).to eq b.id
+    end
+
+    # Guards the invariant that an already-SCORED descendant cannot keep stale
+    # fight_points when an upstream result flips. Propagation routes the slot
+    # change through assign_team_to_slot, which must invalidate the scored side.
+    it "wipes a scored descendant's stale points when its feeding result flips" do
+      r1 = create(:encounter, team_category: tc, team_1: a, team_2: b)
+      r1_other = create(:encounter, team_category: tc, team_1: c, team_2: create(:team, team_category: tc), winner: c)
+      final = create(:encounter, team_category: tc, team_1: nil, team_2: nil,
+        parent_encounter_1: r1, parent_encounter_2: r1_other)
+
+      r1.update!(winner: a) # a advances into final slot 1
+      member(a)
+      member(c)
+      bout = create(:team_fight, encounter: final, kenshi_1: a.kenshis.first, kenshi_2: c.kenshis.first)
+      create(:fight_point, scorable: bout, fighter_side: "fighter_1", kind: "men")
+      final.update!(lineup_1_set: true)
+      expect(final.reload.team_1_id).to eq a.id
+
+      r1.update!(winner: b) # the feeding result flips: b now advances, not a
+
+      bout.reload
+      expect(final.reload.team_1_id).to eq b.id
+      expect(bout.kenshi_1_id).to be_nil
+      expect(bout.fight_points.where(fighter_side: "fighter_1")).to be_empty
+      expect(final.lineup_1_set).to be false
+    end
+  end
+end

--- a/spec/models/fight_point_spec.rb
+++ b/spec/models/fight_point_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FightPoint do
     let(:fight_point) { build(:fight_point) }
 
     it do
-      expect(fight_point).to belong_to(:fight)
+      expect(fight_point).to belong_to(:scorable)
 
       side_values = {fighter_1: "fighter_1", fighter_2: "fighter_2"}
       expect(fight_point)
@@ -30,21 +30,21 @@ RSpec.describe FightPoint do
     let(:fight) { create(:fight) }
 
     it "starts at 1 for the first point on a fight" do
-      point = create(:fight_point, fight: fight)
+      point = create(:fight_point, scorable: fight)
 
       expect(point.position).to eq 1
     end
 
     it "increments per point across both sides to preserve the match timeline" do
-      first = create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men")
-      second = create(:fight_point, fight: fight, fighter_side: "fighter_2", kind: "kote")
-      third = create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "hansoku")
+      first = create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
+      second = create(:fight_point, scorable: fight, fighter_side: "fighter_2", kind: "kote")
+      third = create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "hansoku")
 
       expect([first.position, second.position, third.position]).to eq [1, 2, 3]
     end
 
     it "respects an explicitly supplied position" do
-      point = create(:fight_point, fight: fight, position: 42)
+      point = create(:fight_point, scorable: fight, position: 42)
 
       expect(point.position).to eq 42
     end
@@ -54,28 +54,28 @@ RSpec.describe FightPoint do
     let(:fight) { create(:fight) }
 
     it "rejects a third non-hansoku point on the same side" do
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men")
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "kote")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "kote")
 
-      third = build(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "ippon")
+      third = build(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "ippon")
 
       expect(third).not_to be_valid
       expect(third.errors[:base]).to include("Fighter already has 2 non-hansoku points")
     end
 
     it "does not count hansoku toward the limit" do
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "hansoku")
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "hansoku")
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "hansoku")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "hansoku")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "hansoku")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "hansoku")
 
-      expect(described_class.where(fight: fight, fighter_side: "fighter_1").count).to eq 3
+      expect(described_class.where(scorable: fight, fighter_side: "fighter_1").count).to eq 3
     end
 
     it "tracks the limit independently for each side" do
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men")
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "kote")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "kote")
 
-      opponent_point = build(:fight_point, fight: fight, fighter_side: "fighter_2", kind: "do")
+      opponent_point = build(:fight_point, scorable: fight, fighter_side: "fighter_2", kind: "do")
 
       expect(opponent_point).to be_valid
     end
@@ -94,13 +94,13 @@ RSpec.describe FightPoint do
     it "touches the fight when a point is created" do
       original = fight.updated_at
       travel(1.second) do
-        create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men")
+        create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
       end
       expect(fight.reload.updated_at).to be > original
     end
 
     it "touches the fight when a point is destroyed" do
-      point = create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men")
+      point = create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
       original = fight.reload.updated_at
       travel(1.second) do
         point.destroy!

--- a/spec/models/fight_spec.rb
+++ b/spec/models/fight_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe Fight do
         fighter_1: kenshi1, fighter_2: kenshi2)
       ActiveJob::Base.queue_adapter.enqueued_jobs.clear
 
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
 
       expect(broadcast_targets.join).to include(pool_target_substring)
     end
@@ -423,10 +423,10 @@ RSpec.describe Fight do
     it "broadcasts when a point that does not change the outcome is added" do
       fight = create(:fight, :pool_fight, individual_category: category, pool_number: 1,
         fighter_1: kenshi1, fighter_2: kenshi2)
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
       ActiveJob::Base.queue_adapter.enqueued_jobs.clear
 
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "kote")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "kote")
 
       expect(broadcast_targets.join).to include(pool_target_substring)
     end
@@ -458,7 +458,7 @@ RSpec.describe Fight do
       fight = create(:fight, :pool_fight, individual_category: category, pool_number: 1,
         fighter_1: kenshi1, fighter_2: kenshi2, winner: kenshi2)
 
-      create(:fight_point, fight: fight, fighter_side: "fighter_2", kind: "men")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_2", kind: "men")
 
       expect(participation2.reload.pool_rank).to eq 1
       expect(participation1.reload.pool_rank).to eq 2
@@ -505,7 +505,7 @@ RSpec.describe Fight do
     end
 
     def add_point(side, kind: "men")
-      create(:fight_point, fight: fight, fighter_side: side, kind: kind)
+      create(:fight_point, scorable: fight, fighter_side: side, kind: kind)
     end
 
     it "stays unresolved (the draw default) when there are no points" do
@@ -576,7 +576,7 @@ RSpec.describe Fight do
     it "auto-sets the winner when a point is scored" do
       fight = create(:fight, individual_category: category, fighter_1: kenshi1, fighter_2: kenshi2)
 
-      create(:fight_point, fight: fight, fighter_side: "fighter_2", kind: "men")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_2", kind: "men")
 
       expect(fight.reload.winner_id).to eq kenshi2.id
     end
@@ -584,15 +584,15 @@ RSpec.describe Fight do
     it "stays unresolved at equal points (bracket fights cannot be a draw)" do
       fight = create(:fight, individual_category: category, fighter_1: kenshi1, fighter_2: kenshi2)
 
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men")
-      create(:fight_point, fight: fight, fighter_side: "fighter_2", kind: "men")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_2", kind: "men")
 
       expect(fight.reload).to have_attributes(winner_id: nil, draw: false)
     end
 
     it "clears the winner when the deciding point is removed" do
       fight = create(:fight, individual_category: category, fighter_1: kenshi1, fighter_2: kenshi2)
-      point = create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men")
+      point = create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
       expect(fight.reload.winner_id).to eq kenshi1.id
 
       point.destroy!
@@ -610,7 +610,7 @@ RSpec.describe Fight do
       final = create(:fight, individual_category: category, round: 2,
         fighter_1: nil, fighter_2: nil, parent_fight_1: parent_1, parent_fight_2: parent_2)
 
-      create(:fight_point, fight: final, fighter_side: "fighter_1", kind: "men")
+      create(:fight_point, scorable: final, fighter_side: "fighter_1", kind: "men")
 
       expect(final.reload.winner_id).to eq kenshi1.id
     end
@@ -619,6 +619,33 @@ RSpec.describe Fight do
   # Regression: destroying a fight cascades to its fight_points, whose
   # post-commit outcome recompute used to run on the frozen, already-destroyed
   # fight and raise FrozenError. Covers every user-facing destroy path.
+  describe "#pristine?" do
+    let(:category) { create(:individual_category, pool_size: 2) }
+
+    it "is true for a fresh pool fight" do
+      fight = create(:fight, :pool_fight, individual_category: category)
+      expect(fight.pristine?).to be true
+    end
+
+    it "is false once a winner is recorded" do
+      fight = create(:fight, :pool_fight, individual_category: category)
+      fight.update_column(:winner_id, fight.fighter_1_id)
+      expect(fight.reload.pristine?).to be false
+    end
+
+    it "is false when the fight is a draw" do
+      fight = create(:fight, :pool_fight, individual_category: category)
+      fight.update_column(:draw, true)
+      expect(fight.reload.pristine?).to be false
+    end
+
+    it "is false once a point is scored" do
+      fight = create(:fight, :pool_fight, individual_category: category)
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
+      expect(fight.reload.pristine?).to be false
+    end
+  end
+
   describe "destroying a fight that has recorded points" do
     let(:cup) { create(:cup) }
     let(:category) { create(:individual_category, cup: cup) }
@@ -628,7 +655,7 @@ RSpec.describe Fight do
     it "destroys a pool fight with a recorded point without raising" do
       fight = create(:fight, :pool_fight, individual_category: category, pool_number: 1,
         fighter_1: kenshi1, fighter_2: kenshi2)
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
       expect(fight.reload.winner_id).to eq kenshi1.id
 
       expect { fight.destroy! }.not_to raise_error
@@ -638,7 +665,7 @@ RSpec.describe Fight do
     it "regenerates a pool whose fights have recorded points without raising" do
       fight = create(:fight, :pool_fight, individual_category: category, pool_number: 1,
         fighter_1: kenshi1, fighter_2: kenshi2)
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
 
       expect {
         category.transaction do
@@ -650,7 +677,7 @@ RSpec.describe Fight do
 
     it "force-rebuilds a bracket whose fights have recorded points without raising" do
       fight = create(:fight, individual_category: category, fighter_1: kenshi1, fighter_2: kenshi2)
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
       expect(fight.reload.winner_id).to eq kenshi1.id
 
       expect { category.bracket_fights.destroy_all }.not_to raise_error

--- a/spec/models/individual_category_bracket_builder_spec.rb
+++ b/spec/models/individual_category_bracket_builder_spec.rb
@@ -318,17 +318,17 @@ RSpec.describe IndividualCategoryBracketBuilder do
     # public path (a pool's ranks are spread across halves), so this exercises
     # the safety net directly.
     it "resolves a rest the greedy pass cannot pair without a clash" do
-      builder = described_class.new(category)
+      seeder = BracketSeeder.new([])
       slot = lambda do |pool, rank|
-        IndividualCategoryBracketBuilder::Slot.new(pool_number: pool, pool_rank: rank, participation: nil)
+        BracketSeeder::Slot.new(pool_number: pool, pool_rank: rank, payload: nil)
       end
       # pools [1, 2, 3, 2]: greedy pairs 2.1 vs 2.2 (same pool); grouped resolves it.
       rest = [slot.call(1, 1), slot.call(2, 1), slot.call(3, 1), slot.call(2, 2)]
 
-      greedy = builder.send(:greedy_cross_pool, rest.dup)
-      expect(builder.send(:same_pool?, greedy)).to be(true) # greedy alone clashes
+      greedy = seeder.send(:greedy_cross_pool, rest.dup)
+      expect(seeder.send(:same_pool?, greedy)).to be(true) # greedy alone clashes
 
-      fights = builder.send(:cross_pool_match, rest)
+      fights = seeder.send(:cross_pool_match, rest)
 
       expect(fights.flatten.map { |s| [s.pool_number, s.pool_rank] })
         .to contain_exactly([1, 1], [2, 1], [3, 1], [2, 2])

--- a/spec/models/team_category_bracket_advancement_spec.rb
+++ b/spec/models/team_category_bracket_advancement_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Integration spec spanning the builder, advancement callbacks, and lineup scoring.
+RSpec.describe "Team bracket advancement past round 1" do # rubocop:disable RSpec/DescribeClass
+  let(:cup) { create(:cup) }
+  # team_size must be in [3, 5] (TeamCategory validation), so teams field 3 members.
+  let(:category) { create(:team_category, cup: cup, team_size: 3, pool_size: 3, out_of_pool: 1) }
+
+  def ranked_team(pool_number)
+    team = create(:team, team_category: category, pool_number: pool_number, pool_rank: 1)
+    create_list(:kenshi, 3, cup: cup).each do |k|
+      create(:participation, category: category, team: team, kenshi: k)
+    end
+    team
+  end
+
+  it "fills a round-2 slot from a scored round-1 encounter and lets it be scored" do
+    [1, 2, 3, 4].each { |pool_number| ranked_team(pool_number) }
+
+    TeamCategoryBracketBuilder.new(category).call
+    round_one = category.bracket_encounters.where(round: 1).order(:position).to_a
+    final = category.bracket_encounters.find_by(round: 2)
+
+    # Score the first round-1 encounter: team_1 takes the first bout, going 1–0
+    # in wins, so it is the derived encounter winner.
+    enc = round_one.first
+    EncounterLineup.new(enc).assign(enc.team_1, enc.team_1.kenshis.map(&:id))
+    EncounterLineup.new(enc).assign(enc.team_2, enc.team_2.kenshis.map(&:id))
+    bout = enc.team_fights.order(:position).first
+    create(:fight_point, scorable: bout, fighter_side: "fighter_1", kind: "men")
+
+    enc.reload
+    expect(enc.winner).to eq enc.team_1
+
+    # The winner has advanced into the final's matching slot.
+    final.reload
+    expect([final.team_1_id, final.team_2_id]).to include(enc.team_1_id)
+
+    # And that slot is now scorable (no InvalidLineup).
+    advanced = enc.team_1
+    expect {
+      EncounterLineup.new(final).assign(advanced, advanced.kenshis.map(&:id))
+    }.not_to raise_error
+  end
+end

--- a/spec/models/team_category_bracket_builder_spec.rb
+++ b/spec/models/team_category_bracket_builder_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeamCategoryBracketBuilder do
+  let(:cup) { create(:cup) }
+  let(:category) { create(:team_category, cup: cup, pool_size: 3, out_of_pool: 2) }
+
+  def ranked_team(pool_number:, pool_rank:)
+    create(:team, team_category: category, pool_number: pool_number, pool_rank: pool_rank)
+  end
+
+  context "with 2 pools × 2 ranks" do
+    let!(:t1_1) { ranked_team(pool_number: 1, pool_rank: 1) }
+    let!(:t1_2) { ranked_team(pool_number: 1, pool_rank: 2) }
+    let!(:t2_1) { ranked_team(pool_number: 2, pool_rank: 1) }
+    let!(:t2_2) { ranked_team(pool_number: 2, pool_rank: 2) }
+
+    it "creates a 4-team bracket: 2 first-round encounters + 1 final" do
+      encounters = described_class.new(category).call
+
+      expect(encounters.count { |e| e.round == 1 }).to eq 2
+      expect(encounters.count { |e| e.round == 2 }).to eq 1
+    end
+
+    it "splits each pool's rank-1 and rank-2 across the two first-round encounters" do
+      described_class.new(category).call
+      round_one = category.bracket_encounters.where(round: 1).order(:position)
+
+      round_one.each do |enc|
+        pools = [enc.team_1.pool_number, enc.team_2.pool_number]
+        expect(pools.uniq.size).to eq 2 # cross-pool
+      end
+    end
+
+    it "wires the final to both first-round encounters" do
+      described_class.new(category).call
+      round_one = category.bracket_encounters.where(round: 1).order(:position).to_a
+      final = category.bracket_encounters.find_by(round: 2)
+
+      expect(final.parent_encounter_1).to eq round_one[0]
+      expect(final.parent_encounter_2).to eq round_one[1]
+    end
+  end
+
+  context "with a bye (3 teams)" do
+    let(:category) { create(:team_category, cup: cup, pool_size: 3, out_of_pool: 1) }
+    let!(:t1_1) { ranked_team(pool_number: 1, pool_rank: 1) }
+    let!(:t2_1) { ranked_team(pool_number: 2, pool_rank: 1) }
+    let!(:t3_1) { ranked_team(pool_number: 3, pool_rank: 1) }
+
+    it "seeds the bye team into its round-2 child slot at build time" do
+      described_class.new(category).call
+      final = category.bracket_encounters.find_by(round: 2)
+      bye = category.bracket_encounters.where(round: 1).detect(&:bye?)
+
+      seeded = [final.team_1_id, final.team_2_id]
+      expect(seeded).to include(bye.bye_team.id)
+    end
+  end
+
+  context "idempotency and re-resolve" do
+    let(:category) { create(:team_category, cup: cup, pool_size: 3, out_of_pool: 1) }
+    let!(:t1_1) { ranked_team(pool_number: 1, pool_rank: 1) }
+    let!(:t2_1) { ranked_team(pool_number: 2, pool_rank: 1) }
+
+    it "does not duplicate encounters on a second call" do
+      described_class.new(category).call
+      expect { described_class.new(category).call }
+        .not_to change { category.bracket_encounters.count }
+    end
+
+    it "re-resolves a first-round slot through assign_team_to_slot when ranks change" do
+      described_class.new(category).call
+      enc = category.bracket_encounters.find_by(round: 1, team_1_pool_number: 1)
+      replacement = ranked_team(pool_number: 1, pool_rank: 1)
+      t1_1.update!(pool_rank: nil)
+
+      described_class.new(category).call
+
+      expect(enc.reload.team_1_id).to eq replacement.id
+    end
+
+    it "does not disturb a scored (non-pristine) first-round encounter on a non-force update" do
+      described_class.new(category).call
+      enc = category.bracket_encounters.find_by(round: 1, team_1_pool_number: 1)
+      fight = create(:team_fight, encounter: enc, kenshi_1: create(:kenshi, cup: cup))
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1")
+      expect(enc.reload.pristine?).to be false
+      original_team_1 = enc.team_1_id
+
+      # Ranks change, but a non-force rebuild must preserve in-progress scoring —
+      # discarding it is what the explicit "Force rebuild" path is for.
+      ranked_team(pool_number: 1, pool_rank: 1)
+      t1_1.update!(pool_rank: nil)
+      described_class.new(category).call
+
+      expect(enc.reload.team_1_id).to eq original_team_1
+      expect(fight.reload.fight_points).to be_present
+    end
+  end
+
+  context "force rebuild of a multi-round bracket" do
+    let(:category) { create(:team_category, cup: cup, pool_size: 3, out_of_pool: 1) }
+
+    it "destroys children before parents and rebuilds" do
+      4.times { |i| ranked_team(pool_number: i + 1, pool_rank: 1) }
+      described_class.new(category).call
+      create(:team_fight, encounter: category.bracket_encounters.find_by(round: 1, position: 1))
+      original_ids = category.bracket_encounters.pluck(:id)
+
+      rebuilt = described_class.new(category, rebuild_started: true).call
+
+      expect(rebuilt.size).to eq 3
+      expect(category.bracket_encounters.pluck(:id)).not_to match_array original_ids
+    end
+  end
+
+  context "bracket-only category (no pool phase)" do
+    let(:category) { create(:team_category, cup: cup, pool_size: nil) }
+
+    it "builds a fully resolved bracket from teams, without pool metadata" do
+      teams = create_list(:team, 4, team_category: category)
+
+      encounters = described_class.new(category, random: Random.new(1)).call
+      round_one = category.bracket_encounters.where(round: 1).order(:position)
+
+      expect(encounters.count { |e| e.round == 1 }).to eq 2
+      expect(encounters.count { |e| e.round == 2 }).to eq 1
+      expect(round_one.flat_map { |e| [e.team_1, e.team_2] }).to match_array teams
+      metadata = round_one.pluck(:team_1_pool_number, :team_1_pool_rank,
+        :team_2_pool_number, :team_2_pool_rank).flatten.uniq
+      expect(metadata).to eq [nil]
+    end
+
+    it "builds no bracket for 0 or 1 team" do
+      expect(described_class.new(category).call).to eq []
+
+      create(:team, team_category: category)
+      expect(described_class.new(category).call).to eq []
+      expect(category.bracket_encounters).to be_empty
+    end
+
+    it "seeds a bye's team into its round-2 slot at build time" do
+      create_list(:team, 3, team_category: category)
+
+      described_class.new(category, random: Random.new(1)).call
+      bye = category.bracket_encounters.where(round: 1).detect(&:bye?)
+      final = category.bracket_encounters.find_by(round: 2)
+
+      expect([final.team_1_id, final.team_2_id]).to include bye.bye_team.id
+    end
+
+    it "does not duplicate or reshuffle on a second non-rebuild call" do
+      create_list(:team, 4, team_category: category)
+      first = described_class.new(category, random: Random.new(1)).call
+
+      second = described_class.new(category, random: Random.new(2)).call
+
+      expect(second.map(&:id)).to eq first.map(&:id)
+      expect(second.map(&:team_1_id)).to eq first.map(&:team_1_id)
+    end
+
+    it "redraws on rebuild_started: true" do
+      create_list(:team, 4, team_category: category)
+      described_class.new(category, random: Random.new(1)).call
+      original_ids = category.bracket_encounters.pluck(:id)
+
+      described_class.new(category, rebuild_started: true, random: Random.new(2)).call
+
+      expect(category.bracket_encounters.pluck(:id)).not_to match_array original_ids
+    end
+  end
+end

--- a/spec/models/team_category_spec.rb
+++ b/spec/models/team_category_spec.rb
@@ -31,6 +31,27 @@ RSpec.describe TeamCategory do
     end
   end
 
+  describe "#bracket_encounters" do
+    it "returns only encounters with no pool_number" do
+      tc = create(:team_category)
+      a = create(:team, team_category: tc)
+      b = create(:team, team_category: tc)
+      pool = create(:encounter, team_category: tc, team_1: a, team_2: b, pool_number: 1)
+      bracket = create(:encounter, team_category: tc, team_1: a, team_2: b, round: 1, position: 1)
+
+      expect(tc.bracket_encounters).to include(bracket)
+      expect(tc.bracket_encounters).not_to include(pool)
+    end
+  end
+
+  describe "#bracket_only?" do
+    it "is true when pool_size is nil or 1, false above" do
+      expect(build(:team_category, pool_size: nil).bracket_only?).to be true
+      expect(build(:team_category, pool_size: 1).bracket_only?).to be true
+      expect(build(:team_category, pool_size: 2).bracket_only?).to be false
+    end
+  end
+
   describe "Validations" do
     let(:cup) { create(:cup) }
 
@@ -50,6 +71,23 @@ RSpec.describe TeamCategory do
       expect {
         build(:team_category, cup: cup, gender_restriction: "other")
       }.to raise_error(ArgumentError, /not a valid gender_restriction/)
+    end
+  end
+
+  describe "team_size" do
+    let(:cup) { create(:cup) }
+
+    it "defaults team_size to 5" do
+      expect(build(:team_category).team_size).to eq 5
+    end
+
+    it "accepts a team_size of 3 or 5" do
+      expect(build(:team_category, cup: cup, team_size: 3)).to be_valid
+      expect(build(:team_category, cup: cup, team_size: 5)).to be_valid
+    end
+
+    it "rejects any other team_size" do
+      expect(build(:team_category, cup: cup, team_size: 4)).not_to be_valid
     end
   end
 
@@ -102,6 +140,21 @@ RSpec.describe TeamCategory do
 
         it { expect(team_category.pools.size).to eq 8 }
       end
+    end
+  end
+
+  describe "#team_pools" do
+    it "groups teams by pool_number, ordered by pool_position, ignoring unpooled teams" do
+      tc = create(:team_category, pool_size: 3)
+      a = create(:team, team_category: tc, pool_number: 1, pool_position: 2)
+      b = create(:team, team_category: tc, pool_number: 1, pool_position: 1)
+      c = create(:team, team_category: tc, pool_number: 2, pool_position: 1)
+      create(:team, team_category: tc) # unpooled
+
+      pools = tc.team_pools
+      expect(pools.map(&:number)).to eq [1, 2]
+      expect(pools.first.teams).to eq [b, a]
+      expect(pools.last.teams).to eq [c]
     end
   end
 end

--- a/spec/models/team_fight_spec.rb
+++ b/spec/models/team_fight_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeamFight do
+  let(:tc) { create(:team_category, team_size: 5) }
+  let(:encounter) { create(:encounter, team_category: tc) }
+  let(:k1) { create(:kenshi, cup: tc.cup) }
+  let(:k2) { create(:kenshi, cup: tc.cup) }
+
+  def fight(daihyosen: false, k1_present: true, k2_present: true)
+    create(:team_fight, encounter: encounter, daihyosen: daihyosen,
+      kenshi_1: (k1 if k1_present), kenshi_2: (k2 if k2_present))
+  end
+
+  def point(team_fight, side, kind: "men")
+    create(:fight_point, scorable: team_fight, fighter_side: side, kind: kind)
+  end
+
+  it "awards the win to the side with more points" do
+    tf = fight
+    point(tf, "fighter_1")
+    expect(tf.reload).to have_attributes(winner_id: k1.id, draw: false)
+  end
+
+  it "declares hikiwake at 1-1" do
+    tf = fight
+    point(tf, "fighter_1")
+    point(tf, "fighter_2")
+    expect(tf.reload).to have_attributes(winner_id: nil, draw: true)
+  end
+
+  it "resets a both-present bout to pending (not hikiwake) when its last point is removed" do
+    tf = fight
+    p = point(tf, "fighter_1")
+    expect(tf.reload).to have_attributes(winner_id: k1.id, draw: false)
+
+    p.destroy!
+    # Back to 0-0 with no points: the bout is unscored/pending, NOT an automatic
+    # hikiwake. A genuine 0-0 draw is the admin's explicit call.
+    expect(tf.reload).to have_attributes(winner_id: nil, draw: false)
+  end
+
+  it "wins immediately at two points (sanbon-shobu)" do
+    tf = fight
+    point(tf, "fighter_1", kind: "men")
+    point(tf, "fighter_1", kind: "kote")
+    expect(tf.reload).to have_attributes(winner_id: k1.id, draw: false)
+  end
+
+  it "treats a one-sided lineup as a forfeit win for the present side" do
+    tf = fight(k2_present: false)
+    tf.resolve_lineup! # forfeit resolution is triggered by EncounterLineup, not on create
+    expect(tf.reload).to have_attributes(winner_id: k1.id, draw: false)
+    expect(tf.individual_points(1)).to eq 2
+    expect(tf.individual_points(2)).to eq 0
+  end
+
+  it "leaves a daihyosen undecided at 0-0 (no hikiwake)" do
+    tf = fight(daihyosen: true)
+    tf.recompute_outcome_from_points!
+    expect(tf.reload).to have_attributes(winner_id: nil, draw: false)
+  end
+
+  it "decides a daihyosen on the first point (ippon-shobu)" do
+    tf = fight(daihyosen: true)
+    point(tf, "fighter_2")
+    expect(tf.reload).to have_attributes(winner_id: k2.id, draw: false)
+  end
+
+  describe "#void?" do
+    it "is true only when both kenshi slots are empty" do
+      both_empty = create(:team_fight, encounter: encounter, kenshi_1: nil, kenshi_2: nil)
+      one_side = create(:team_fight, encounter: encounter, kenshi_1: k1, kenshi_2: nil)
+      both = create(:team_fight, encounter: encounter, kenshi_1: k1, kenshi_2: k2)
+
+      expect(both_empty.void?).to be true
+      expect(one_side.void?).to be false
+      expect(both.void?).to be false
+    end
+  end
+
+  describe "#hikiwake_eligible?" do
+    let(:tc) { create(:team_category, team_size: 3) }
+    let(:t1) { create(:team, team_category: tc) }
+    let(:t2) { create(:team, team_category: tc) }
+    let(:encounter) do
+      create(:encounter, team_category: tc, team_1: t1, team_2: t2,
+        lineup_1_set: true, lineup_2_set: true)
+    end
+    let(:a) { create(:kenshi, cup: tc.cup) }
+    let(:b) { create(:kenshi, cup: tc.cup) }
+
+    it "is true for a confirmed, both-present, unscored, winner-less regular bout" do
+      tf = create(:team_fight, encounter: encounter, kenshi_1: a, kenshi_2: b)
+      expect(tf.hikiwake_eligible?).to be true
+    end
+
+    it "is false when a lineup is not confirmed" do
+      encounter.update!(lineup_2_set: false)
+      tf = create(:team_fight, encounter: encounter, kenshi_1: a, kenshi_2: b)
+      expect(tf.hikiwake_eligible?).to be false
+    end
+
+    it "is false for a forfeit (one side empty)" do
+      tf = create(:team_fight, encounter: encounter, kenshi_1: a, kenshi_2: nil)
+      expect(tf.hikiwake_eligible?).to be false
+    end
+
+    it "is false once the bout has points" do
+      tf = create(:team_fight, encounter: encounter, kenshi_1: a, kenshi_2: b)
+      create(:fight_point, scorable: tf, fighter_side: "fighter_1", kind: "men")
+      expect(tf.reload.hikiwake_eligible?).to be false
+    end
+
+    it "is false for a winner-bearing bout" do
+      tf = create(:team_fight, encounter: encounter, kenshi_1: a, kenshi_2: b, winner: a)
+      expect(tf.hikiwake_eligible?).to be false
+    end
+
+    it "is false for the daihyosen bout" do
+      tf = create(:team_fight, encounter: encounter, kenshi_1: a, kenshi_2: b,
+        daihyosen: true, position: tc.team_size + 1)
+      expect(tf.hikiwake_eligible?).to be false
+    end
+  end
+end

--- a/spec/models/team_pooler_spec.rb
+++ b/spec/models/team_pooler_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeamPooler do
+  let(:tc) { create(:team_category, pool_size: 3) }
+
+  def team(seed: nil) = create(:team, team_category: tc, seed: seed)
+
+  it "puts the seeded teams into distinct pools" do
+    seeds = [team(seed: 1), team(seed: 2), team(seed: 3), team(seed: 4)]
+    8.times { team }
+
+    described_class.new(tc, random: Random.new(1)).set_pools
+
+    pool_numbers = seeds.map { |s| s.reload.pool_number }
+    expect(pool_numbers.uniq.size).to eq 4 # all in different pools
+  end
+
+  it "sizes pools with the fewest short pools (11 teams, size 3 -> 3,3,3,2)" do
+    11.times { team }
+    described_class.new(tc, random: Random.new(1)).set_pools
+
+    sizes = tc.teams.where.not(pool_number: nil).group_by(&:pool_number).values.map(&:size).sort
+    expect(sizes).to eq [2, 3, 3, 3]
+  end
+
+  it "assigns a 1-based pool_position within each pool" do
+    6.times { team }
+    described_class.new(tc, random: Random.new(1)).set_pools
+
+    tc.team_pools.each do |pool|
+      expect(pool.teams.map(&:pool_position)).to eq (1..pool.teams.size).to_a
+    end
+  end
+
+  it "is deterministic for a given seed" do
+    9.times { team }
+    described_class.new(tc, random: Random.new(42)).set_pools
+    first = tc.teams.order(:id).map(&:pool_number)
+
+    described_class.new(tc, random: Random.new(42)).set_pools
+    expect(tc.teams.order(:id).reload.map(&:pool_number)).to eq first
+  end
+
+  it "clears pool assignments when pool_size <= 1" do
+    single = create(:team_category, pool_size: 1)
+    t = create(:team, team_category: single, pool_number: 1, pool_position: 1)
+
+    described_class.new(single).set_pools
+
+    expect(t.reload.pool_number).to be_nil
+  end
+end

--- a/spec/models/team_position_spec.rb
+++ b/spec/models/team_position_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeamPosition do
+  describe ".label" do
+    it "names the five roles of a full team" do
+      labels = (1..5).map { |position| described_class.label(position, 5) }
+      expect(labels).to eq ["1. Sempo", "2. Jiho", "3. Chuken", "4. Fukusho", "5. Taisho"]
+    end
+
+    it "names the three roles of a three-fighter team (leadoff, centre, anchor)" do
+      labels = (1..3).map { |position| described_class.label(position, 3) }
+      expect(labels).to eq ["1. Sempo", "2. Chuken", "3. Taisho"]
+    end
+
+    it "falls back to a plain position label for sizes without conventional roles" do
+      expect(described_class.label(2, 4)).to eq "Position 2"
+    end
+  end
+end

--- a/spec/pdfs/team_category_bracket_pdf_spec.rb
+++ b/spec/pdfs/team_category_bracket_pdf_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeamCategoryBracketPdf do
+  let(:cup) { create(:cup) }
+  let(:category) { create(:team_category, cup: cup, pool_size: 3, out_of_pool: 2) }
+
+  def ranked_team(pool_number:, pool_rank:)
+    create(:team, team_category: category, pool_number: pool_number, pool_rank: pool_rank)
+  end
+
+  it "renders a single-page bracket on one page" do
+    ranked_team(pool_number: 1, pool_rank: 1)
+    ranked_team(pool_number: 1, pool_rank: 2)
+    ranked_team(pool_number: 2, pool_rank: 1)
+    ranked_team(pool_number: 2, pool_rank: 2)
+    TeamCategoryBracketBuilder.new(category).call
+
+    expect(described_class.new(category).page_count).to eq 1
+  end
+
+  it "renders an empty-state page when no bracket has been generated" do
+    expect(described_class.new(category).page_count).to eq 1
+  end
+
+  it "splits a bracket whose first round exceeds one page into multiple panels" do
+    # 20 pools each contributing 2 qualifiers gives a 32-team bracket: 16
+    # first-round encounters, more than max_rows_per_page (10).
+    20.times do |i|
+      ranked_team(pool_number: i + 1, pool_rank: 1)
+      ranked_team(pool_number: i + 1, pool_rank: 2)
+    end
+    TeamCategoryBracketBuilder.new(category).call
+
+    expect(described_class.new(category).page_count).to be > 1
+  end
+end

--- a/spec/requests/admin/encounters/daihyosens_spec.rb
+++ b/spec/requests/admin/encounters/daihyosens_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin encounter daihyosen" do
+  let(:cup) { create(:cup) }
+  let(:tc) { create(:team_category, cup: cup, team_size: 3) }
+  let(:t1) { create(:team, team_category: tc) }
+  let(:t2) { create(:team, team_category: tc) }
+  let(:admin) { create(:user, :admin) }
+  let(:encounter) { create(:encounter, team_category: tc, team_1: t1, team_2: t2) }
+
+  before { sign_in admin }
+
+  def member(team)
+    create(:kenshi, cup: cup).tap { |k| create(:participation, category: tc, team: team, kenshi: k) }
+  end
+
+  it "changes a rep to another member of the same team" do
+    a1 = member(t1)
+    a2 = member(t1)
+    b1 = member(t2)
+    daihyosen = create(:team_fight, encounter: encounter, daihyosen: true,
+      position: tc.team_size + 1, kenshi_1: a1, kenshi_2: b1)
+
+    patch admin_team_category_encounter_daihyosen_path(tc, encounter),
+      params: {kenshi_1_id: a2.id}, as: :turbo_stream
+
+    expect(daihyosen.reload.kenshi_1_id).to eq a2.id
+    expect(daihyosen.kenshi_2_id).to eq b1.id # untouched
+  end
+
+  it "rejects a rep that is not on that team" do
+    a1 = member(t1)
+    b1 = member(t2)
+    intruder = member(t2) # on team 2, not team 1
+    daihyosen = create(:team_fight, encounter: encounter, daihyosen: true,
+      position: tc.team_size + 1, kenshi_1: a1, kenshi_2: b1)
+
+    patch admin_team_category_encounter_daihyosen_path(tc, encounter),
+      params: {kenshi_1_id: intruder.id}, as: :turbo_stream
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(daihyosen.reload.kenshi_1_id).to eq a1.id
+  end
+
+  it "returns 422 (not 500) when a rep is set on an unresolved team slot" do
+    b1 = member(t2)
+    # A round-1 bracket encounter whose team_1 has not resolved yet (nil, no
+    # parent winner): member_id would call nil.kenshis and 500 without the guard.
+    unresolved = create(:encounter, team_category: tc, team_1: nil, team_2: t2, round: 1)
+    create(:team_fight, encounter: unresolved, daihyosen: true,
+      position: tc.team_size + 1, kenshi_2: b1)
+
+    patch admin_team_category_encounter_daihyosen_path(tc, unresolved),
+      params: {kenshi_1_id: b1.id}, as: :turbo_stream
+
+    expect(response).to have_http_status(:unprocessable_content)
+  end
+
+  it "rejects a rep change once the daihyosen has points" do
+    a1 = member(t1)
+    a2 = member(t1)
+    b1 = member(t2)
+    daihyosen = create(:team_fight, encounter: encounter, daihyosen: true,
+      position: tc.team_size + 1, kenshi_1: a1, kenshi_2: b1)
+    create(:fight_point, scorable: daihyosen, fighter_side: "fighter_1", kind: "men")
+
+    patch admin_team_category_encounter_daihyosen_path(tc, encounter),
+      params: {kenshi_1_id: a2.id}, as: :turbo_stream
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(daihyosen.reload.kenshi_1_id).to eq a1.id
+  end
+end

--- a/spec/requests/admin/encounters/lineup_seeds_spec.rb
+++ b/spec/requests/admin/encounters/lineup_seeds_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin encounter lineup seeds" do
+  let(:cup) { create(:cup) }
+  let(:tc) { create(:team_category, cup: cup, team_size: 3) }
+  let(:t1) { create(:team, team_category: tc) }
+  let(:t2) { create(:team, team_category: tc) }
+  let(:admin) { create(:user, :admin) }
+
+  before { sign_in admin }
+
+  def members(team, count)
+    create_list(:kenshi, count, cup: cup).each do |k|
+      create(:participation, category: tc, team: team, kenshi: k)
+    end
+  end
+
+  it "seeds the suggested order and confirms the lineups" do
+    a = members(t1, 3)
+    members(t2, 3)
+    previous = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    EncounterLineup.new(previous).assign(t1, [a[2].id, a[0].id, a[1].id])
+
+    fresh = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    post admin_team_category_encounter_lineup_seed_path(tc, fresh), as: :turbo_stream
+
+    expect(response).to have_http_status(:ok)
+    expect(fresh.team_fights.order(:position).map(&:kenshi_1_id)).to eq [a[2].id, a[0].id, a[1].id]
+    expect(fresh.reload.lineup_1_set?).to be true
+  end
+
+  it "requires an admin" do
+    sign_out admin
+    fresh = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+
+    post admin_team_category_encounter_lineup_seed_path(tc, fresh)
+
+    expect(response).not_to have_http_status(:ok)
+    expect(fresh.team_fights).to be_empty
+  end
+end

--- a/spec/requests/admin/encounters_spec.rb
+++ b/spec/requests/admin/encounters_spec.rb
@@ -1,0 +1,276 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin encounters" do
+  let(:cup) { create(:cup) }
+  let(:tc) { create(:team_category, cup: cup, team_size: 3) }
+  let(:t1) { create(:team, team_category: tc) }
+  let(:t2) { create(:team, team_category: tc) }
+  let(:admin) { create(:user, :admin) }
+
+  before { sign_in admin }
+
+  def member(team)
+    create(:kenshi, cup: cup).tap { |k| create(:participation, category: tc, team: team, kenshi: k) }
+  end
+
+  it "creates an encounter between two teams" do
+    post admin_team_category_encounters_path(tc), params: {encounter: {team_1_id: t1.id, team_2_id: t2.id}}
+
+    encounter = Encounter.last
+    expect(encounter.team_1).to eq t1
+    expect(response).to redirect_to(admin_team_category_encounter_path(tc, encounter))
+  end
+
+  it "lists encounters, including bracket encounters whose teams are unresolved (nil)" do
+    create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    # A round-1 bracket encounter resolves its teams through parent winners, so
+    # team_1/team_2 are nil. The index must render them via the nil-safe
+    # team_display_name helper rather than crashing on nil.name.
+    create(:encounter, team_category: tc, team_1: nil, team_2: nil, round: 1)
+
+    get admin_team_category_encounters_path(tc)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("To be decided")
+  end
+
+  it "renders a pool encounter without the bracket panel frame or Close button" do
+    encounter = create(:encounter, team_category: tc, team_1: t1, team_2: t2, pool_number: 1)
+
+    get admin_team_category_encounter_path(tc, encounter)
+
+    expect(response.body).not_to include("encounter_panel_team_category_")
+    expect(response.body).not_to include("encounter-panel#close")
+  end
+
+  it "sets a team's lineup, creating bouts" do
+    encounter = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    members = Array.new(3) { member(t1) }
+
+    patch admin_team_category_encounter_lineup_path(tc, encounter),
+      params: {team_id: t1.id, kenshi_ids: members.map(&:id)}
+
+    expect(encounter.team_fights.count).to eq 3
+    expect(encounter.team_fights.order(:position).map(&:kenshi_1_id)).to eq members.map(&:id)
+  end
+
+  it "keeps a blank middle slot at its position instead of moving it last" do
+    encounter = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    members = Array.new(3) { member(t1) }
+
+    # The middle dropdown is left unselected ("—"), so it arrives as an empty string.
+    patch admin_team_category_encounter_lineup_path(tc, encounter),
+      params: {team_id: t1.id, kenshi_ids: [members[0].id, "", members[2].id]}
+
+    expect(encounter.team_fights.order(:position).map(&:kenshi_1_id))
+      .to eq [members[0].id, nil, members[2].id]
+  end
+
+  it "scores a bout and re-derives the encounter winner" do
+    encounter = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    fight = create(:team_fight, encounter: encounter, kenshi_1: member(t1), kenshi_2: member(t2))
+
+    post admin_team_category_encounter_team_fight_team_fight_points_path(tc, encounter, fight),
+      params: {team_fight_point: {fighter_side: "fighter_1", kind: "men"}}
+
+    expect(fight.reload.winner_id).to eq fight.kenshi_1_id
+    expect(encounter.reload.winner).to eq t1
+  end
+
+  it "removes a recorded point" do
+    encounter = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    fight = create(:team_fight, encounter: encounter, kenshi_1: member(t1), kenshi_2: member(t2))
+    point = create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
+
+    delete admin_team_category_encounter_team_fight_team_fight_point_path(tc, encounter, fight, point)
+
+    expect(fight.fight_points).to be_empty
+    expect(fight.reload.winner_id).to be_nil
+  end
+
+  it "returns 422 for an invalid point kind instead of crashing" do
+    encounter = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    fight = create(:team_fight, encounter: encounter, kenshi_1: member(t1), kenshi_2: member(t2))
+
+    post admin_team_category_encounter_team_fight_team_fight_points_path(tc, encounter, fight),
+      params: {team_fight_point: {fighter_side: "fighter_1", kind: "bogus"}}
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(fight.fight_points).to be_empty
+  end
+
+  it "redirects non-admins away" do
+    sign_out admin
+    sign_in create(:user)
+
+    post admin_team_category_encounters_path(tc), params: {encounter: {team_1_id: t1.id, team_2_id: t2.id}}
+
+    expect(response).to redirect_to(root_url)
+    expect(Encounter.count).to eq 0
+  end
+
+  it "renders the standalone encounter page" do
+    encounter = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+
+    get admin_team_category_encounter_path(tc, encounter)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include(t1.name) # team names head their columns
+    expect(response.body).to include(t2.name)
+    expect(response.body).to include("lineup") # the lineup forms render
+  end
+
+  it "pre-selects the assigned fighters in the in-table dropdowns" do
+    encounter = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    members = Array.new(3) { member(t1) }
+    EncounterLineup.new(encounter).assign(t1, members.map(&:id))
+
+    get admin_team_category_encounter_path(tc, encounter)
+
+    expect(response).to have_http_status(:ok)
+    members.each do |kenshi|
+      expect(response.body).to include(%(<option selected="selected" value="#{kenshi.id}">))
+    end
+  end
+
+  it "shows a fighter dropdown for every position before any lineup is set" do
+    encounter = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    member(t1)
+    member(t2)
+    expect(encounter.team_fights).to be_empty # pool encounters start without bouts
+
+    get admin_team_category_encounter_path(tc, encounter)
+
+    expect(response).to have_http_status(:ok)
+    # team_size positions × 2 sides, each an auto-submitting kenshi dropdown.
+    expect(response.body.scan('name="kenshi_ids[]"').size).to eq(tc.team_size * 2)
+    form_id = "lineup_#{ActionView::RecordIdentifier.dom_id(encounter)}_team_#{t1.id}"
+    expect(response.body).to include(%(form="#{form_id}"))
+    expect(response.body).to include(%(<form id="#{form_id}"))
+  end
+
+  it "surfaces a lineup error in the panel instead of failing silently" do
+    encounter = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    outsider = create(:kenshi, cup: cup) # not a member of t1
+
+    patch admin_team_category_encounter_lineup_path(tc, encounter),
+      params: {team_id: t1.id, kenshi_ids: [outsider.id]}, as: :turbo_stream
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("member not on team")
+  end
+
+  it "renders the pool-match scoring layout for a bout" do
+    encounter = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    create(:team_fight, encounter: encounter, kenshi_1: member(t1), kenshi_2: member(t2))
+
+    get admin_team_category_encounter_path(tc, encounter)
+
+    expect(response).to have_http_status(:ok)
+    # Reuses the same two-sided scoring card as the individual category pools.
+    expect(response.body).to include("pool-match__sides")
+    expect(response.body).to include("pool-match__button")
+  end
+
+  describe "POST team_swap" do
+    let(:bracket_only) { create(:team_category, cup: cup, pool_size: nil) }
+
+    before do
+      create_list(:team, 4, team_category: bracket_only)
+      TeamCategoryBracketBuilder.new(bracket_only, random: Random.new(1)).call
+    end
+
+    def round_one
+      bracket_only.bracket_encounters.where(round: 1).order(:position).to_a
+    end
+
+    it "swaps two round-1 occupants and redirects with a notice" do
+      first, second = round_one
+      moving_in = second.team_1
+
+      post admin_team_category_encounter_team_swap_path(bracket_only, first),
+        params: {slot: 1, team_id: moving_in.id}
+
+      expect(response).to redirect_to(admin_team_category_path(bracket_only))
+      expect(flash[:notice]).to be_present
+      expect(first.reload.team_1).to eq moving_in
+    end
+
+    it "redirects with an alert on an invalid swap" do
+      first, second = round_one
+      second.update!(winner: second.team_1)
+
+      post admin_team_category_encounter_team_swap_path(bracket_only, first),
+        params: {slot: 1, team_id: second.team_1.id}
+
+      expect(response).to redirect_to(admin_team_category_path(bracket_only))
+      expect(flash[:alert]).to include("recorded results")
+      expect(first.reload.team_1).not_to eq second.team_1
+    end
+
+    it "renders swap selects on a pristine bracket-only round-1 encounter" do
+      get admin_team_category_encounter_path(bracket_only, round_one.first)
+
+      expect(response.body).to include("swap-team__form")
+    end
+
+    it "renders no swap controls once the encounter has results" do
+      encounter = round_one.first
+      encounter.update!(winner: encounter.team_1)
+
+      get admin_team_category_encounter_path(bracket_only, encounter)
+
+      expect(response.body).not_to include("swap-team__form")
+    end
+
+    it "renders no swap controls on a final (round 2)" do
+      final = bracket_only.bracket_encounters.find_by(round: 2)
+
+      get admin_team_category_encounter_path(bracket_only, final)
+
+      expect(response.body).not_to include("swap-team__form")
+    end
+  end
+
+  describe "the encounter _summary partial" do
+    def render_summary(encounter)
+      ApplicationController.render(partial: "admin/encounters/summary", locals: {encounter: encounter})
+    end
+
+    def bout(encounter, pos, result)
+      tf = encounter.team_fights.create!(position: pos,
+        kenshi_1: create(:kenshi, cup: cup), kenshi_2: create(:kenshi, cup: cup))
+      case result
+      when 1 then create(:fight_point, scorable: tf, fighter_side: "fighter_1", kind: "men")
+      when 2 then create(:fight_point, scorable: tf, fighter_side: "fighter_2", kind: "men")
+      when :draw then tf.update!(draw: true)
+      end
+    end
+
+    it "reads 'not yet scored' before the encounter is complete" do
+      encounter = create(:encounter, team_category: tc, pool_number: 1, team_1: t1, team_2: t2)
+      bout(encounter, 1, 1) # one bout scored, lineups not flagged complete
+      expect(render_summary(encounter.reload)).to include("not yet scored")
+    end
+
+    it "shows the winner once complete" do
+      encounter = create(:encounter, team_category: tc, pool_number: 1, team_1: t1, team_2: t2)
+      bout(encounter, 1, 1)
+      bout(encounter, 2, 1)
+      bout(encounter, 3, 2)
+      encounter.update!(lineup_1_set: true, lineup_2_set: true)
+      expect(render_summary(encounter.reload)).to include("→ #{t1.name}")
+    end
+
+    it "shows hikiwake on a completed tie" do
+      encounter = create(:encounter, team_category: tc, pool_number: 1, team_1: t1, team_2: t2)
+      bout(encounter, 1, 1)
+      bout(encounter, 2, 2)
+      bout(encounter, 3, :draw)
+      encounter.update!(lineup_1_set: true, lineup_2_set: true)
+      expect(render_summary(encounter.reload)).to include("hikiwake")
+    end
+  end
+end

--- a/spec/requests/admin/fight_points_spec.rb
+++ b/spec/requests/admin/fight_points_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe "Admin fight points" do
     end
 
     it "rejects a third non-hansoku point on the same side" do
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men")
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "kote")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "kote")
 
       post admin_individual_category_fight_fight_points_path(category, fight), params: {
         fight_point: {fighter_side: "fighter_1", kind: "ippon"}
@@ -48,7 +48,7 @@ RSpec.describe "Admin fight points" do
 
   describe "DELETE /admin/individual_categories/:cat/fights/:fight/fight_points/:id" do
     it "removes the point" do
-      point = create(:fight_point, fight: fight, fighter_side: "fighter_2", kind: "do")
+      point = create(:fight_point, scorable: fight, fighter_side: "fighter_2", kind: "do")
 
       delete admin_individual_category_fight_fight_point_path(category, fight, point)
 
@@ -66,8 +66,8 @@ RSpec.describe "Admin fight points" do
     }
 
     it "renders the pool with a flash alert instead of raising" do
-      create(:fight_point, fight: pool_fight, fighter_side: "fighter_1", kind: "men")
-      create(:fight_point, fight: pool_fight, fighter_side: "fighter_1", kind: "kote")
+      create(:fight_point, scorable: pool_fight, fighter_side: "fighter_1", kind: "men")
+      create(:fight_point, scorable: pool_fight, fighter_side: "fighter_1", kind: "kote")
 
       post admin_individual_category_pool_fight_fight_points_path(category, pool_fight),
         params: {fight_point: {fighter_side: "fighter_1", kind: "ippon"}},

--- a/spec/requests/admin/individual_categories_bracket_spec.rb
+++ b/spec/requests/admin/individual_categories_bracket_spec.rb
@@ -10,13 +10,15 @@ RSpec.describe "Admin individual category brackets" do
   before { sign_in admin }
 
   describe "GET /admin/individual_categories/:id" do
-    it "renders pool positions and pool ranks as editable in place" do
+    it "renders pool ranks as editable in place and pool positions read-only" do
       create_qualified_participation(pool_number: 1, pool_rank: 1)
 
       get admin_individual_category_path(category)
 
-      expect(response.body).to include("data-bip-attribute=\"pool_position\"")
+      # pool_rank stays inline-editable; pool_position is owned by the
+      # drag-and-drop move tool and is rendered read-only.
       expect(response.body).to include("data-bip-attribute=\"pool_rank\"")
+      expect(response.body).not_to include("data-bip-attribute=\"pool_position\"")
       expect(response.body).to include("/assets/admin-")
       expect(response.body).to include("type=\"module\"")
     end
@@ -70,8 +72,8 @@ RSpec.describe "Admin individual category brackets" do
       create_qualified_participation(pool_number: 2, pool_rank: 1)
       IndividualCategoryBracketBuilder.new(category).call
       fight = category.fights.first
-      create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men")
-      create(:fight_point, fight: fight, fighter_side: "fighter_2", kind: "hansoku")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
+      create(:fight_point, scorable: fight, fighter_side: "fighter_2", kind: "hansoku")
 
       get competition_tree_pdf_admin_individual_category_path(category)
 

--- a/spec/requests/admin/individual_category_show_spec.rb
+++ b/spec/requests/admin/individual_category_show_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin individual category show page" do
+  let(:cup) { create(:cup) }
+  let(:admin) { create(:user, :admin) }
+
+  before { sign_in admin }
+
+  it "renders the pools panel with the unpooled component when pool_size > 1" do
+    category = create(:individual_category, cup: cup, pool_size: 3)
+    create(:participation, category: category, kenshi: create(:kenshi, cup: cup),
+      pool_number: 1, pool_position: 1)
+    create(:participation, category: category, kenshi: create(:kenshi, cup: cup), pool_number: nil)
+
+    get admin_individual_category_path(category)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("individual_pools_#{category.id}")
+    expect(response.body).to include("individual_pool_unpooled_#{category.id}")
+    expect(response.body).to include("Unpooled participants")
+  end
+
+  it "shows the plain unpooled fallback for a non-pooled category (pool_size <= 1)" do
+    category = create(:individual_category, cup: cup, pool_size: 1)
+    create(:participation, category: category, kenshi: create(:kenshi, cup: cup), pool_number: nil)
+
+    get admin_individual_category_path(category)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include("individual_pool_unpooled_#{category.id}")
+  end
+end

--- a/spec/requests/admin/individual_pool_memberships_spec.rb
+++ b/spec/requests/admin/individual_pool_memberships_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin individual pool memberships" do
+  let(:cup) { create(:cup) }
+  let(:category) { create(:individual_category, cup: cup, pool_size: 3, out_of_pool: 2) }
+  let(:admin) { create(:user, :admin) }
+
+  before { sign_in admin }
+
+  def member_in(pool, position)
+    create(:participation, category: category, kenshi: create(:kenshi, cup: cup),
+      pool_number: pool, pool_position: position)
+  end
+
+  def move(participation, to_pool, **params)
+    patch admin_individual_category_pool_membership_path(category, participation),
+      params: {to_pool_number: to_pool, **params},
+      as: :turbo_stream
+  end
+
+  it "moves a member and replaces both pool cards" do
+    member_in(1, 1)
+    b = member_in(1, 2)
+    member_in(2, 1)
+
+    move(b, 2)
+
+    expect(response).to have_http_status(:ok)
+    expect(b.reload.pool_number).to eq 2
+    expect(response.body).to include("target=\"#{ActionView::RecordIdentifier.dom_id(category, "pool_1")}\"")
+    expect(response.body).to include("target=\"#{ActionView::RecordIdentifier.dom_id(category, "pool_2")}\"")
+  end
+
+  it "removes the source pool card when the move empties it" do
+    lonely = member_in(1, 1)
+    member_in(2, 1)
+
+    move(lonely, 2)
+
+    expect(response.body).to include(
+      "turbo-stream action=\"remove\" target=\"#{ActionView::RecordIdentifier.dom_id(category, "pool_1")}\""
+    )
+  end
+
+  it "answers 422 with a message when the move is destructive and unforced" do
+    member_in(1, 1)
+    b = member_in(1, 2)
+    member_in(1, 3)
+    member_in(2, 1)
+    PoolFightGenerator.new(category).call
+    category.pool_fights.where(pool_number: 1).first.update_column(:draw, true)
+
+    move(b, 2)
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body["message"]).to be_present
+    expect(b.reload.pool_number).to eq 1
+  end
+
+  it "performs the destructive move when forced (the JS confirm-retry path)" do
+    member_in(1, 1)
+    b = member_in(1, 2)
+    member_in(1, 3)
+    member_in(2, 1)
+    PoolFightGenerator.new(category).call
+    category.pool_fights.where(pool_number: 1).first.update_column(:draw, true)
+
+    move(b, 2, force: true)
+
+    expect(response).to have_http_status(:ok)
+    expect(b.reload.pool_number).to eq 2
+  end
+
+  it "un-pools a member when the destination is blank, refreshing the unpooled panel" do
+    member_in(1, 1)
+    b = member_in(1, 2)
+
+    move(b, "")
+
+    expect(response).to have_http_status(:ok)
+    expect(b.reload.pool_number).to be_nil
+    expect(response.body).to include("target=\"individual_pool_unpooled_#{category.id}\"")
+  end
+
+  it "creates a new pool by replacing the pools container (idempotent — no double-apply on the acting admin)" do
+    member_in(1, 1)
+    member_in(1, 2)
+    late = create(:participation, category: category, kenshi: create(:kenshi, cup: cup), pool_number: nil)
+
+    move(late, 2)
+
+    expect(response).to have_http_status(:ok)
+    expect(late.reload.pool_number).to eq 2
+    expect(response.body).to include(
+      "turbo-stream action=\"replace\" target=\"individual_pools_#{category.id}\""
+    )
+    expect(response.body).not_to include("action=\"append\"")
+  end
+
+  it "redirects non-admins away" do
+    sign_out admin
+    sign_in create(:user)
+    member_in(1, 1)
+    b = member_in(1, 2)
+
+    move(b, 2)
+
+    expect(response).to redirect_to(root_url)
+    expect(b.reload.pool_number).to eq 1
+  end
+end

--- a/spec/requests/admin/pool_memberships_spec.rb
+++ b/spec/requests/admin/pool_memberships_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin pool memberships" do
+  let(:cup) { create(:cup) }
+  let(:tc) { create(:team_category, cup: cup, pool_size: 3, out_of_pool: 2, team_size: 3) }
+  let(:admin) { create(:user, :admin) }
+
+  before { sign_in admin }
+
+  def team_in(pool, position)
+    create(:team, team_category: tc, pool_number: pool, pool_position: position)
+  end
+
+  def move(team, to_pool, **params)
+    patch admin_team_category_pool_membership_path(tc, team),
+      params: {to_pool_number: to_pool, **params},
+      as: :turbo_stream
+  end
+
+  it "moves a team and replaces both pool cards" do
+    team_in(1, 1)
+    b = team_in(1, 2)
+    team_in(2, 1)
+
+    move(b, 2)
+
+    expect(response).to have_http_status(:ok)
+    expect(b.reload.pool_number).to eq 2
+    expect(response.body).to include("turbo-stream action=\"replace\" target=\"team_pool_#{tc.id}_1\"")
+    expect(response.body).to include("turbo-stream action=\"replace\" target=\"team_pool_#{tc.id}_2\"")
+  end
+
+  it "removes the source pool card when the move empties it" do
+    lonely = team_in(1, 1)
+    team_in(2, 1)
+
+    move(lonely, 2)
+
+    expect(response.body).to include("turbo-stream action=\"remove\" target=\"team_pool_#{tc.id}_1\"")
+  end
+
+  it "answers 422 with a message when the move is destructive and unforced" do
+    team_in(1, 1)
+    b = team_in(1, 2)
+    team_in(1, 3)
+    team_in(2, 1)
+    PoolEncounterGenerator.new(tc).call
+    tc.encounters.where(pool_number: 1).first.update!(lineup_1_set: true)
+
+    move(b, 2)
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body["message"]).to be_present
+    expect(b.reload.pool_number).to eq 1
+  end
+
+  it "performs the destructive move when forced" do
+    team_in(1, 1)
+    b = team_in(1, 2)
+    team_in(1, 3)
+    team_in(2, 1)
+    PoolEncounterGenerator.new(tc).call
+    tc.encounters.where(pool_number: 1).first.update!(lineup_1_set: true)
+
+    move(b, 2, force: true)
+
+    expect(response).to have_http_status(:ok)
+    expect(b.reload.pool_number).to eq 2
+  end
+
+  it "adds an unpooled team to an existing pool and refreshes the unpooled panel" do
+    team_in(1, 1)
+    team_in(1, 2)
+    late = create(:team, team_category: tc, pool_number: nil)
+
+    move(late, 1)
+
+    expect(response).to have_http_status(:ok)
+    expect(late.reload.pool_number).to eq 1
+    expect(response.body).to include("turbo-stream action=\"replace\" target=\"team_pool_#{tc.id}_1\"")
+    expect(response.body).to include("turbo-stream action=\"replace\" target=\"team_pool_unpooled_#{tc.id}\"")
+  end
+
+  it "creates a new pool by replacing the pools container (idempotent — no double-apply on the acting admin)" do
+    team_in(1, 1)
+    team_in(1, 2)
+    late = create(:team, team_category: tc, pool_number: nil)
+
+    move(late, 2)
+
+    expect(response).to have_http_status(:ok)
+    expect(late.reload.pool_number).to eq 2
+    expect(response.body).to include("turbo-stream action=\"replace\" target=\"team_pools_#{tc.id}\"")
+    expect(response.body).not_to include("action=\"append\"")
+  end
+
+  it "un-pools a team when the destination is blank, refreshing the source and unpooled panel" do
+    team_in(1, 1)
+    b = team_in(1, 2)
+
+    move(b, "")
+
+    expect(response).to have_http_status(:ok)
+    expect(b.reload.pool_number).to be_nil
+    expect(response.body).to include("turbo-stream action=\"replace\" target=\"team_pool_unpooled_#{tc.id}\"")
+    # no destination pool card stream (there is no destination pool)
+    expect(response.body).not_to include("target=\"team_pool_#{tc.id}_\"")
+  end
+
+  it "redirects non-admins away" do
+    sign_out admin
+    sign_in create(:user)
+    team_in(1, 1)
+    b = team_in(1, 2)
+
+    move(b, 2)
+
+    expect(response).to redirect_to(root_url)
+    expect(b.reload.pool_number).to eq 1
+  end
+end

--- a/spec/requests/admin/team_categories_bracket_spec.rb
+++ b/spec/requests/admin/team_categories_bracket_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin team category brackets" do
+  let(:cup) { create(:cup) }
+  let(:category) { create(:team_category, cup: cup, pool_size: 3, out_of_pool: 1) }
+  let(:admin) { create(:user, :admin) }
+
+  before { sign_in admin }
+
+  describe "POST /admin/team_categories/:id/generate_bracket" do
+    it "generates bracket encounters for the category" do
+      create(:team, team_category: category, pool_number: 1, pool_rank: 1)
+      create(:team, team_category: category, pool_number: 2, pool_rank: 1)
+
+      post generate_bracket_admin_team_category_path(category)
+
+      expect(response).to redirect_to(admin_team_category_path(category))
+      expect(category.bracket_encounters.where(round: 1).count).to eq 1
+    end
+
+    it "redirects non-admin users away" do
+      sign_out admin
+      sign_in create(:user)
+
+      post generate_bracket_admin_team_category_path(category)
+
+      expect(response).to redirect_to(root_url)
+      expect(category.bracket_encounters).to be_empty
+    end
+
+    it "replaces the bracket tree via turbo stream instead of redirecting" do
+      create(:team, team_category: category, pool_number: 1, pool_rank: 1)
+      create(:team, team_category: category, pool_number: 2, pool_rank: 1)
+
+      post generate_bracket_admin_team_category_path(category),
+        headers: {"Accept" => "text/vnd.turbo-stream.html"}
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include(
+        %(target="encounter_tree_team_category_#{category.id}")
+      )
+      expect(category.bracket_encounters.where(round: 1).count).to eq 1
+    end
+  end
+
+  describe "GET /admin/team_categories/:id (bracket panel)" do
+    it "renders the bracket tree once encounters exist" do
+      create(:team, team_category: category, pool_number: 1, pool_rank: 1)
+      create(:team, team_category: category, pool_number: 2, pool_rank: 1)
+      TeamCategoryBracketBuilder.new(category).call
+
+      get admin_team_category_path(category)
+
+      expect(response.body).to include("encounter_tree_team_category_#{category.id}")
+    end
+
+    it "renders an empty encounter panel frame below the tree" do
+      create(:team, team_category: category, pool_number: 1, pool_rank: 1)
+      create(:team, team_category: category, pool_number: 2, pool_rank: 1)
+      TeamCategoryBracketBuilder.new(category).call
+
+      get admin_team_category_path(category)
+
+      # Assert the frame element itself, not just the id string — the tree's
+      # card links already carry it as a data-turbo-frame attribute value.
+      expect(response.body).to match(
+        %r{<turbo-frame [^>]*id="encounter_panel_team_category_#{category.id}"\s*>}
+      )
+    end
+  end
+
+  describe "GET a bracket encounter (framed in the panel below the tree)" do
+    it "renders the encounter inside the panel frame with a Close button" do
+      create(:team, team_category: category, pool_number: 1, pool_rank: 1)
+      create(:team, team_category: category, pool_number: 2, pool_rank: 1)
+      TeamCategoryBracketBuilder.new(category).call
+      encounter = category.bracket_encounters.first
+
+      get admin_team_category_encounter_path(category, encounter)
+
+      expect(response.body).to match(
+        %r{<turbo-frame [^>]*id="encounter_panel_team_category_#{category.id}"}
+      )
+      expect(response.body).to match(
+        %r{<button[^>]*data-action="encounter-panel#close"[^>]*>Close</button>}
+      )
+      expect(response.body).not_to include("Back to tree")
+    end
+  end
+
+  describe "POST /admin/team_categories/:id/generate_bracket?rebuild=1" do
+    it "force-rebuilds the bracket" do
+      create(:team, team_category: category, pool_number: 1, pool_rank: 1)
+      create(:team, team_category: category, pool_number: 2, pool_rank: 1)
+      TeamCategoryBracketBuilder.new(category).call
+      original_ids = category.bracket_encounters.pluck(:id)
+
+      post generate_bracket_admin_team_category_path(category, rebuild: 1)
+
+      expect(category.bracket_encounters.pluck(:id)).not_to match_array(original_ids)
+    end
+  end
+
+  describe "bracket-only category" do
+    let(:bracket_only) { create(:team_category, cup: cup, pool_size: nil) }
+
+    it "generates a bracket straight from teams" do
+      create_list(:team, 4, team_category: bracket_only)
+
+      post generate_bracket_admin_team_category_path(bracket_only)
+
+      expect(bracket_only.bracket_encounters.where(round: 1).count).to eq 2
+      expect(bracket_only.bracket_encounters.where(round: 1).pluck(:team_1_pool_number).uniq).to eq [nil]
+    end
+
+    it "refuses pool generation server-side" do
+      post generate_pools_admin_team_category_path(bracket_only)
+
+      expect(response).to redirect_to(admin_team_category_path(bracket_only))
+      expect(flash[:alert]).to be_present
+    end
+
+    it "refuses pool encounter generation server-side" do
+      post generate_pool_encounters_admin_team_category_path(bracket_only)
+
+      expect(response).to redirect_to(admin_team_category_path(bracket_only))
+      expect(flash[:alert]).to be_present
+      expect(bracket_only.encounters).to be_empty
+    end
+
+    it "hides pool action items and the Update bracket link" do
+      create_list(:team, 4, team_category: bracket_only)
+      TeamCategoryBracketBuilder.new(bracket_only).call
+
+      get admin_team_category_path(bracket_only)
+
+      expect(response.body).not_to include("Generate pools")
+      expect(response.body).not_to include("Generate pool encounters")
+      expect(response.body).not_to include("Update bracket")
+      expect(response.body).to include("Force rebuild")
+    end
+
+    it "keeps pool actions for a pooled category" do
+      get admin_team_category_path(category)
+
+      expect(response.body).to include("Generate pools")
+      expect(response.body).to include("Generate pool encounters")
+    end
+  end
+end

--- a/spec/requests/admin/team_fights_spec.rb
+++ b/spec/requests/admin/team_fights_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin team fights" do
+  let(:cup) { create(:cup) }
+  let(:tc) { create(:team_category, cup: cup, team_size: 3) }
+  let(:t1) { create(:team, team_category: tc) }
+  let(:t2) { create(:team, team_category: tc) }
+  let(:admin) { create(:user, :admin) }
+  let(:encounter) do
+    create(:encounter, team_category: tc, team_1: t1, team_2: t2,
+      lineup_1_set: true, lineup_2_set: true)
+  end
+  let(:a) { create(:kenshi, cup: cup) }
+  let(:b) { create(:kenshi, cup: cup) }
+
+  before { sign_in admin }
+
+  it "marks an eligible bout hikiwake and clears it again" do
+    fight = create(:team_fight, encounter: encounter, kenshi_1: a, kenshi_2: b)
+
+    patch admin_team_category_encounter_team_fight_path(tc, encounter, fight),
+      params: {team_fight: {draw: true}}, as: :turbo_stream
+    expect(fight.reload.draw).to be true
+
+    patch admin_team_category_encounter_team_fight_path(tc, encounter, fight),
+      params: {team_fight: {draw: false}}, as: :turbo_stream
+    expect(fight.reload.draw).to be false
+  end
+
+  it "rejects a draw on an ineligible (scored) bout" do
+    fight = create(:team_fight, encounter: encounter, kenshi_1: a, kenshi_2: b)
+    create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
+
+    patch admin_team_category_encounter_team_fight_path(tc, encounter, fight),
+      params: {team_fight: {draw: true}}, as: :turbo_stream
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(fight.reload.draw).to be false
+  end
+
+  it "rejects a draw when the lineups are not both confirmed" do
+    encounter.update!(lineup_2_set: false)
+    fight = create(:team_fight, encounter: encounter, kenshi_1: a, kenshi_2: b)
+
+    patch admin_team_category_encounter_team_fight_path(tc, encounter, fight),
+      params: {team_fight: {draw: true}}, as: :turbo_stream
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(fight.reload.draw).to be false
+  end
+
+  it "auto-creates the daihyosen when the final hikiwake ties the encounter" do
+    fighters_1 = Array.new(3) { create(:kenshi, cup: cup) }
+    fighters_2 = Array.new(3) { create(:kenshi, cup: cup) }
+    fighters_1.each { |k| create(:participation, category: tc, team: t1, kenshi: k) }
+    fighters_2.each { |k| create(:participation, category: tc, team: t2, kenshi: k) }
+    EncounterLineup.new(encounter).assign(t1, fighters_1.map(&:id))
+    EncounterLineup.new(encounter).assign(t2, fighters_2.map(&:id))
+    fights = encounter.team_fights.order(:position).to_a
+
+    fights.each do |fight|
+      patch admin_team_category_encounter_team_fight_path(tc, encounter, fight),
+        params: {team_fight: {draw: true}}, as: :turbo_stream
+    end
+
+    daihyosen = encounter.team_fights.find_by(daihyosen: true)
+    expect(daihyosen).to be_present
+    expect(daihyosen.kenshi_1_id).to eq fighters_1.last.id
+    expect(daihyosen.kenshi_2_id).to eq fighters_2.last.id
+    # The triggering response already carries the new row (no stale-cache omission).
+    expect(response.body).to include("Daihyōsen")
+  end
+end

--- a/spec/requests/admin/team_pools_spec.rb
+++ b/spec/requests/admin/team_pools_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin team pools" do
+  let(:cup) { create(:cup) }
+  let(:tc) { create(:team_category, cup: cup, pool_size: 3) }
+  let(:admin) { create(:user, :admin) }
+
+  before { sign_in admin }
+
+  it "generates pools across the category's teams" do
+    6.times { create(:team, team_category: tc) }
+
+    post generate_pools_admin_team_category_path(tc)
+
+    expect(tc.teams.where.not(pool_number: nil).count).to eq 6
+    expect(response).to redirect_to(admin_team_category_path(tc))
+  end
+
+  it "generates pool encounters once pools exist" do
+    3.times { |i| create(:team, team_category: tc, pool_number: 1, pool_position: i + 1) }
+
+    post generate_pool_encounters_admin_team_category_path(tc)
+
+    expect(tc.encounters.where(pool_number: 1).count).to eq 3 # round-robin of 3
+    expect(response).to redirect_to(admin_team_category_path(tc))
+  end
+
+  it "renders the admin show page with the pool panel (admin best_in_place path)" do
+    3.times { |i| create(:team, team_category: tc, pool_number: 1, pool_position: i + 1) }
+
+    get admin_team_category_path(tc)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Pool 1")
+  end
+
+  it "redirects non-admins away" do
+    sign_out admin
+    sign_in create(:user)
+    post generate_pools_admin_team_category_path(tc)
+    expect(response).to redirect_to(root_url)
+  end
+
+  it "renders the admin standings partial (best_in_place) without raising" do
+    create(:team, team_category: tc, pool_number: 1, pool_position: 1)
+
+    html = ApplicationController.render(
+      partial: "admin/team_categories/pool_standings",
+      locals: {team_category: tc, pool_number: 1, admin: true}
+    )
+
+    expect(html).to include("team_pool_standings_#{tc.id}_1")
+    expect(html).to include("data-bip-attribute=\"pool_rank\"") # best_in_place admin variant
+  end
+
+  it "renders the non-admin standings partial without best_in_place" do
+    create(:team, team_category: tc, pool_number: 1, pool_position: 1)
+
+    html = ApplicationController.render(
+      partial: "admin/team_categories/pool_standings",
+      locals: {team_category: tc, pool_number: 1, admin: false}
+    )
+
+    expect(html).to include("team_pool_standings_#{tc.id}_1")
+    expect(html).not_to include("data-bip-attribute") # plain ranks, no inline editing
+  end
+end

--- a/spec/services/bracket_display_numbering_spec.rb
+++ b/spec/services/bracket_display_numbering_spec.rb
@@ -57,6 +57,27 @@ RSpec.describe BracketDisplayNumbering do
     end
   end
 
+  describe "with team encounters" do
+    let(:tc) { create(:team_category) }
+
+    def team = create(:team, team_category: tc)
+
+    it "numbers encounters leaf-first, skipping byes" do
+      r1a = create(:encounter, team_category: tc, team_1: team, team_2: team, round: 1, position: 1, number: 1)
+      r1b = create(:encounter, team_category: tc, team_1: team, team_2: nil, round: 1, position: 2, number: 2)
+      final = create(:encounter, team_category: tc, round: 2, position: 1, number: 3,
+        parent_encounter_1: r1a, parent_encounter_2: r1b)
+
+      list = [r1a, r1b, final]
+      Encounter.preload_parents(list)
+      numbers = described_class.for(list)
+
+      expect(numbers[r1b.id]).to be_nil
+      expect(numbers[r1a.id]).to eq 1
+      expect(numbers[final.id]).to eq 2
+    end
+  end
+
   def loaded_fights
     fights = category.bracket_fights.bracket_order.to_a
     Fight.preload_parents(fights)

--- a/spec/services/bracket_only_seeder_spec.rb
+++ b/spec/services/bracket_only_seeder_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BracketOnlySeeder do
+  let(:cup) { create(:cup) }
+  let(:category) { create(:team_category, cup: cup, pool_size: nil) }
+
+  # seeds: maps team index -> seed value, e.g. {0 => 1, 1 => 2}
+  def make_teams(count, seeds: {})
+    Array.new(count) { |i| create(:team, team_category: category, seed: seeds[i]) }
+  end
+
+  def flat(pairs)
+    pairs.flatten.compact
+  end
+
+  it "returns no pairs for 0 or 1 team" do
+    expect(described_class.new([]).first_round_pairs).to eq []
+    expect(described_class.new(make_teams(1)).first_round_pairs).to eq []
+  end
+
+  it "pairs 2 teams into a single fight with no byes" do
+    teams = make_teams(2)
+    pairs = described_class.new(teams, random: Random.new(1)).first_round_pairs
+
+    expect(pairs.size).to eq 1
+    expect(flat(pairs)).to match_array teams
+  end
+
+  it "never duplicates or drops a team and pads to a power of two" do
+    [3, 5, 8, 9].each do |n|
+      teams = make_teams(n)
+      seeder = described_class.new(teams, random: Random.new(7))
+      pairs = seeder.first_round_pairs
+
+      expect(pairs.size).to eq seeder.bracket_size / 2
+      expect(flat(pairs)).to match_array teams
+    end
+  end
+
+  it "gives byes to seeded teams first" do
+    teams = make_teams(6, seeds: {0 => 1, 1 => 2}) # bracket of 8 -> 2 byes
+    pairs = described_class.new(teams, random: Random.new(3)).first_round_pairs
+
+    bye_recipients = pairs.filter_map { |pair| pair.first if pair[1].nil? }
+    expect(bye_recipients).to contain_exactly(teams[0], teams[1])
+  end
+
+  it "spreads byes so no two byes meet in round 2 when avoidable" do
+    teams = make_teams(12) # bracket of 16 -> 4 byes across 8 units
+    pairs = described_class.new(teams, random: Random.new(3)).first_round_pairs
+
+    pairs.each_slice(2) do |unit_a, unit_b|
+      expect([unit_a, unit_b].count { |pair| pair[1].nil? }).to be <= 1
+    end
+  end
+
+  it "fills remaining byes with random unseeded teams after the seeds" do
+    teams = make_teams(5, seeds: {0 => 1}) # bracket of 8 -> 3 byes
+    pairs = described_class.new(teams, random: Random.new(3)).first_round_pairs
+
+    bye_recipients = pairs.filter_map { |pair| pair.first if pair[1].nil? }
+    expect(bye_recipients.size).to eq 3
+    expect(bye_recipients).to include teams[0]
+  end
+
+  it "places seed 1 in the first unit and seed 2 in the last" do
+    teams = make_teams(8, seeds: {0 => 1, 1 => 2})
+    pairs = described_class.new(teams, random: Random.new(3)).first_round_pairs
+
+    expect(pairs.first).to include teams[0]
+    expect(pairs.last).to include teams[1]
+  end
+
+  it "places seeds 3 and 4 at the quarter boundaries, projecting 1v4 and 2v3 semis" do
+    teams = make_teams(8, seeds: {0 => 1, 1 => 2, 2 => 3, 3 => 4})
+    pairs = described_class.new(teams, random: Random.new(3)).first_round_pairs
+
+    expect(pairs[1]).to include teams[3] # seed 4 shares the top half with seed 1
+    expect(pairs[2]).to include teams[2] # seed 3 shares the bottom half with seed 2
+  end
+
+  it "places seeds beyond 4 at the next protected positions" do
+    teams = make_teams(16, seeds: {0 => 1, 1 => 2, 2 => 3, 3 => 4, 4 => 5})
+    pairs = described_class.new(teams, random: Random.new(3)).first_round_pairs
+
+    # standard layout for 8 units is [1, 8, 4, 5, 6, 3, 7, 2] -> seed 5 at unit 3,
+    # projecting the 4v5 quarterfinal
+    expect(pairs[3]).to include teams[4]
+  end
+
+  it "pairs each non-bye seed against an unseeded team while any remain" do
+    teams = make_teams(8, seeds: {0 => 1, 1 => 2})
+    pairs = described_class.new(teams, random: Random.new(3)).first_round_pairs
+
+    [teams[0], teams[1]].each do |seed|
+      pair = pairs.find { |p| p.include?(seed) }
+      opponent = (pair - [seed]).first
+      expect(opponent.seed).to be_nil
+    end
+  end
+
+  it "pairs leftover seeds strongest vs weakest in an all-seeded field" do
+    teams = make_teams(4, seeds: {0 => 1, 1 => 2, 2 => 3, 3 => 4})
+    pairs = described_class.new(teams, random: Random.new(3)).first_round_pairs
+
+    expect(pairs).to eq [[teams[0], teams[3]], [teams[1], teams[2]]]
+  end
+
+  it "breaks duplicate seed values deterministically by id" do
+    teams = make_teams(4, seeds: {0 => 1, 1 => 1})
+    pairs = described_class.new(teams, random: Random.new(5)).first_round_pairs
+
+    expect(pairs.first).to include teams[0] # lower id takes the top spot
+    expect(pairs.last).to include teams[1]
+  end
+
+  it "is deterministic for a given RNG with no seeded teams" do
+    teams = make_teams(8)
+    # Two seeder instances with equal RNG seeds: not an identical expression.
+    first_draw = described_class.new(teams, random: Random.new(11)).first_round_pairs
+    second_draw = described_class.new(teams, random: Random.new(11)).first_round_pairs
+    expect(second_draw).to eq first_draw # rubocop:disable RSpec/IdenticalEqualityAssertion
+  end
+end

--- a/spec/services/bracket_seeder_spec.rb
+++ b/spec/services/bracket_seeder_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BracketSeeder do
+  def slot(pool, rank)
+    BracketSeeder::Slot.new(pool_number: pool, pool_rank: rank, payload: "#{pool}.#{rank}")
+  end
+
+  it "returns no pairs for an empty field" do
+    expect(described_class.new([]).first_round_pairs).to eq []
+  end
+
+  it "gives a single entry a bye (no opponent)" do
+    expect(described_class.new([slot(1, 1)]).first_round_pairs).to eq [[slot(1, 1), nil]]
+  end
+
+  it "lays out 4 pools × 2 ranks as a cross-pool draw with same-pool ranks split" do
+    rank_major = [slot(1, 1), slot(2, 1), slot(3, 1), slot(4, 1),
+      slot(1, 2), slot(2, 2), slot(3, 2), slot(4, 2)]
+    pairs = described_class.new(rank_major).first_round_pairs
+
+    expect(pairs).to eq([
+      [slot(1, 1), slot(3, 2)],
+      [slot(2, 1), slot(4, 2)],
+      [slot(3, 1), slot(1, 2)],
+      [slot(4, 1), slot(2, 2)]
+    ])
+  end
+
+  it "derives bracket_size as the next power of two" do
+    expect(described_class.new([slot(1, 1), slot(2, 1), slot(3, 1)]).bracket_size).to eq 4
+  end
+end

--- a/spec/services/daihyosen_proposal_spec.rb
+++ b/spec/services/daihyosen_proposal_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DaihyosenProposal do
+  let(:tc) { create(:team_category, team_size: 3) }
+  let(:t1) { create(:team, team_category: tc) }
+  let(:t2) { create(:team, team_category: tc) }
+  let(:encounter) do
+    create(:encounter, team_category: tc, team_1: t1, team_2: t2,
+      lineup_1_set: true, lineup_2_set: true)
+  end
+
+  # Three drawn both-present bouts -> complete and level (0-0 wins, 0-0 ippons).
+  # Returns the [team_1_fighters, team_2_fighters] arrays so examples can assert
+  # on the taishō without leaning on instance variables.
+  def level_complete!
+    a = Array.new(3) { create(:kenshi, cup: tc.cup) }
+    b = Array.new(3) { create(:kenshi, cup: tc.cup) }
+    (1..3).each do |position|
+      create(:team_fight, encounter: encounter, position: position,
+        kenshi_1: a[position - 1], kenshi_2: b[position - 1], draw: true)
+    end
+    [a, b]
+  end
+
+  it "creates a daihyosen of each team's last fighter, unconfirmed/unscored" do
+    a, b = level_complete!
+
+    described_class.new(encounter.reload).ensure!
+
+    d = encounter.team_fights.find_by(daihyosen: true)
+    expect(d).to be_present
+    expect(d.position).to eq tc.team_size + 1
+    expect(d.kenshi_1_id).to eq a.last.id
+    expect(d.kenshi_2_id).to eq b.last.id
+    expect(d.winner_id).to be_nil
+  end
+
+  it "is idempotent (no duplicate on a second call)" do
+    level_complete!
+    described_class.new(encounter.reload).ensure!
+    described_class.new(encounter.reload).ensure!
+    expect(encounter.team_fights.where(daihyosen: true).count).to eq 1
+  end
+
+  it "picks the last non-blank position as taisho (skips a trailing void)" do
+    a = Array.new(2) { create(:kenshi, cup: tc.cup) }
+    b = Array.new(2) { create(:kenshi, cup: tc.cup) }
+    create(:team_fight, encounter: encounter, position: 1, kenshi_1: a[0], kenshi_2: b[0], draw: true)
+    create(:team_fight, encounter: encounter, position: 2, kenshi_1: a[1], kenshi_2: b[1], draw: true)
+    create(:team_fight, encounter: encounter, position: 3, kenshi_1: nil, kenshi_2: nil) # void both sides
+
+    described_class.new(encounter.reload).ensure!
+
+    d = encounter.team_fights.find_by(daihyosen: true)
+    expect(d.kenshi_1_id).to eq a[1].id # position 2, not the void position 3
+    expect(d.kenshi_2_id).to eq b[1].id
+  end
+
+  it "does nothing for a pool encounter" do
+    encounter.update!(pool_number: 1)
+    level_complete!
+    described_class.new(encounter.reload).ensure!
+    expect(encounter.team_fights.where(daihyosen: true)).to be_empty
+  end
+
+  it "does nothing while the encounter is incomplete" do
+    a = Array.new(3) { create(:kenshi, cup: tc.cup) }
+    b = Array.new(3) { create(:kenshi, cup: tc.cup) }
+    (1..3).each do |position|
+      create(:team_fight, encounter: encounter, position: position,
+        kenshi_1: a[position - 1], kenshi_2: b[position - 1]) # unresolved
+    end
+    described_class.new(encounter.reload).ensure!
+    expect(encounter.team_fights.where(daihyosen: true)).to be_empty
+  end
+end

--- a/spec/services/encounter_lineup_seeder_spec.rb
+++ b/spec/services/encounter_lineup_seeder_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EncounterLineupSeeder do
+  let(:tc) { create(:team_category, team_size: 3) }
+  let(:t1) { create(:team, team_category: tc) }
+  let(:t2) { create(:team, team_category: tc) }
+
+  def members(team, count)
+    create_list(:kenshi, count, cup: tc.cup).each do |k|
+      create(:participation, category: tc, team: team, kenshi: k)
+    end
+  end
+
+  it "seeds both sides from their previous order and confirms them" do
+    a = members(t1, 3)
+    b = members(t2, 3)
+    prev1 = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    EncounterLineup.new(prev1).assign(t1, [a[1].id, a[0].id, a[2].id])
+    EncounterLineup.new(prev1).assign(t2, b.map(&:id))
+
+    fresh = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    described_class.new(fresh).call
+
+    fights = fresh.team_fights.order(:position)
+    expect(fights.map(&:kenshi_1_id)).to eq [a[1].id, a[0].id, a[2].id]
+    expect(fights.map(&:kenshi_2_id)).to eq b.map(&:id)
+    # Seeding confirms, so an opened encounter is immediately usable.
+    expect(fresh.reload.lineup_1_set?).to be true
+    expect(fresh.lineup_2_set?).to be true
+  end
+
+  it "falls back to roster order for a team with no history" do
+    roster = members(t1, 3)
+    members(t2, 3)
+    fresh = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+
+    described_class.new(fresh).call
+
+    expect(fresh.team_fights.order(:position).map(&:kenshi_1_id)).to eq roster.map(&:id)
+  end
+
+  it "leaves an already-confirmed side untouched" do
+    a = members(t1, 3)
+    members(t2, 3)
+    fresh = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    EncounterLineup.new(fresh).assign(t1, [a[2].id, a[1].id, a[0].id])
+
+    described_class.new(fresh).call
+
+    # The confirmed order stands; seeding doesn't overwrite it.
+    expect(fresh.team_fights.order(:position).map(&:kenshi_1_id)).to eq [a[2].id, a[1].id, a[0].id]
+    expect(fresh.reload.lineup_1_set?).to be true
+  end
+
+  it "does not re-seed a side it already filled" do
+    a = members(t1, 3)
+    members(t2, 3)
+    fresh = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    described_class.new(fresh).call # first seed lays down + confirms roster order
+    reordered = a.reverse
+
+    # A manual reorder of the already-filled side; a second call must not overwrite it.
+    EncounterLineup.new(fresh).assign(t1, reordered.map(&:id))
+    described_class.new(fresh).call
+
+    expect(fresh.team_fights.order(:position).map(&:kenshi_1_id)).to eq reordered.map(&:id)
+  end
+
+  it "is a no-op for a team with no members" do
+    members(t2, 3)
+    fresh = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+
+    expect { described_class.new(fresh).call }.not_to raise_error
+    expect(fresh.team_fights.map(&:kenshi_1_id)).to all(be_nil)
+  end
+end

--- a/spec/services/encounter_lineup_spec.rb
+++ b/spec/services/encounter_lineup_spec.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EncounterLineup do
+  let(:tc) { create(:team_category, team_size: 3) }
+  let(:t1) { create(:team, team_category: tc) }
+  let(:t2) { create(:team, team_category: tc) }
+  let(:encounter) { create(:encounter, team_category: tc, team_1: t1, team_2: t2) }
+
+  def members(team, count)
+    create_list(:kenshi, count, cup: tc.cup).each do |k|
+      create(:participation, category: tc, team: team, kenshi: k)
+    end
+  end
+
+  it "creates team_size bouts and fills the chosen side in order" do
+    m = members(t1, 3)
+    described_class.new(encounter).assign(t1, m.map(&:id))
+
+    fights = encounter.team_fights.order(:position)
+    expect(fights.size).to eq 3
+    expect(fights.map(&:kenshi_1_id)).to eq m.map(&:id)
+    expect(fights.map(&:kenshi_2_id)).to all(be_nil)
+  end
+
+  it "pairs positions once both sides are assigned" do
+    a = members(t1, 3)
+    b = members(t2, 3)
+    described_class.new(encounter).assign(t1, a.map(&:id))
+    described_class.new(encounter).assign(t2, b.map(&:id))
+
+    fights = encounter.team_fights.order(:position)
+    expect(fights.map(&:kenshi_1_id)).to eq a.map(&:id)
+    expect(fights.map(&:kenshi_2_id)).to eq b.map(&:id)
+  end
+
+  it "leaves trailing positions empty (forfeit) for a short team" do
+    a = members(t1, 3)
+    short = members(t2, 2)
+    described_class.new(encounter).assign(t1, a.map(&:id))
+    described_class.new(encounter).assign(t2, short.map(&:id))
+
+    last = encounter.team_fights.order(:position).last
+    expect(last.kenshi_2_id).to be_nil
+    expect(last.reload.winner_id).to eq a.last.id # forfeit win
+  end
+
+  it "keeps a blank middle position in place instead of shifting fighters up" do
+    m = members(t1, 3)
+    described_class.new(encounter).assign(t1, [m[0].id, nil, m[2].id])
+
+    fights = encounter.team_fights.order(:position)
+    expect(fights.map(&:kenshi_1_id)).to eq [m[0].id, nil, m[2].id]
+  end
+
+  it "clears a previously filled position when it is re-submitted blank" do
+    m = members(t1, 3)
+    described_class.new(encounter).assign(t1, m.map(&:id))
+    described_class.new(encounter).assign(t1, [m[0].id, nil, m[2].id])
+
+    fights = encounter.team_fights.order(:position)
+    expect(fights.map(&:kenshi_1_id)).to eq [m[0].id, nil, m[2].id]
+  end
+
+  it "swaps two fighters when their positions are re-submitted exchanged" do
+    m = members(t1, 3)
+    described_class.new(encounter).assign(t1, m.map(&:id))
+    # Drag-to-reorder posts the same ids with positions 1 and 3 exchanged.
+    described_class.new(encounter).assign(t1, [m[2].id, m[1].id, m[0].id])
+
+    expect(encounter.team_fights.order(:position).map(&:kenshi_1_id))
+      .to eq [m[2].id, m[1].id, m[0].id]
+  end
+
+  it "selects a subset when a team has more members than team_size" do
+    six = members(t1, 6) # team_size is 3
+    chosen = six.first(3)
+    described_class.new(encounter).assign(t1, chosen.map(&:id))
+    expect(encounter.team_fights.order(:position).map(&:kenshi_1_id)).to eq chosen.map(&:id)
+  end
+
+  describe "#seed" do
+    it "places the fighters without confirming the side" do
+      m = members(t1, 3)
+      described_class.new(encounter).seed(t1, m.map(&:id))
+
+      expect(encounter.team_fights.order(:position).map(&:kenshi_1_id)).to eq m.map(&:id)
+      expect(encounter.reload.lineup_1_set?).to be false
+    end
+
+    it "does not resolve forfeits even when both sides are seeded" do
+      a = members(t1, 3)
+      short = members(t2, 2)
+      described_class.new(encounter).seed(t1, a.map(&:id))
+      described_class.new(encounter).seed(t2, short.map(&:id))
+
+      # An unconfirmed seed must not hand out forfeit wins for the empty slot.
+      last = encounter.team_fights.order(:position).last
+      expect(last.winner_id).to be_nil
+      expect(encounter.reload.lineup_1_set?).to be false
+      expect(encounter.lineup_2_set?).to be false
+    end
+
+    it "still keeps a blank middle slot in place" do
+      m = members(t1, 3)
+      described_class.new(encounter).seed(t1, [m[0].id, nil, m[2].id])
+
+      expect(encounter.team_fights.order(:position).map(&:kenshi_1_id))
+        .to eq [m[0].id, nil, m[2].id]
+    end
+  end
+
+  it "rejects a kenshi who is not on the team" do
+    outsider = create(:kenshi, cup: tc.cup)
+    expect {
+      described_class.new(encounter).assign(t1, [outsider.id])
+    }.to raise_error(EncounterLineup::InvalidLineup)
+  end
+
+  it "rejects duplicate members" do
+    m = members(t1, 1).first
+    expect {
+      described_class.new(encounter).assign(t1, [m.id, m.id])
+    }.to raise_error(EncounterLineup::InvalidLineup)
+  end
+
+  it "rejects more members than team_size" do
+    m = members(t1, 4)
+    expect {
+      described_class.new(encounter).assign(t1, m.map(&:id))
+    }.to raise_error(EncounterLineup::InvalidLineup)
+  end
+
+  it "rejects a team that is not part of the encounter" do
+    other = create(:team, team_category: tc)
+    expect {
+      described_class.new(encounter).assign(other, [])
+    }.to raise_error(EncounterLineup::InvalidLineup)
+  end
+
+  it "resets a scored bout (clears its points) when its fighter is reordered" do
+    a = members(t1, 3)
+    b = members(t2, 3)
+    described_class.new(encounter).assign(t1, a.map(&:id))
+    described_class.new(encounter).assign(t2, b.map(&:id))
+    scored = encounter.team_fights.order(:position).first
+    create(:fight_point, scorable: scored, fighter_side: "fighter_1", kind: "men")
+
+    # Reorder team 1: swap positions 1 and 3. Position 1's matchup changes, so
+    # its recorded points/outcome are cleared and the bout is left unresolved.
+    described_class.new(encounter).assign(t1, [a[2].id, a[1].id, a[0].id])
+
+    scored.reload
+    expect(scored.kenshi_1_id).to eq a[2].id # the moved-in fighter
+    expect(scored.fight_points).to be_empty  # old points cleared
+    expect(scored.winner_id).to be_nil
+    expect(scored.draw).to be false          # unresolved, not auto-hikiwake
+  end
+
+  it "fills the empty opposing side even after the present side has scored" do
+    a = members(t1, 3)
+    described_class.new(encounter).assign(t1, a.map(&:id))
+    scored = encounter.team_fights.order(:position).first
+    create(:fight_point, scorable: scored, fighter_side: "fighter_1", kind: "men")
+
+    b = members(t2, 3)
+    expect {
+      described_class.new(encounter).assign(t2, b.map(&:id))
+    }.not_to raise_error
+
+    expect(scored.reload.kenshi_2_id).to eq b.first.id # opponent entered late
+    expect(scored.fight_points.size).to eq 1 # the existing point is preserved
+    expect(scored.winner_id).to eq a.first.id # and so is the recorded winner
+  end
+
+  it "re-assigning a side leaves the other side's kenshi untouched" do
+    a = members(t1, 3)
+    b = members(t2, 3)
+    replacement = members(t1, 3)
+    described_class.new(encounter).assign(t1, a.map(&:id))
+    described_class.new(encounter).assign(t2, b.map(&:id))
+    described_class.new(encounter).assign(t1, replacement.map(&:id))
+
+    fights = encounter.team_fights.order(:position)
+    expect(fights.map(&:kenshi_1_id)).to eq replacement.map(&:id)
+    expect(fights.map(&:kenshi_2_id)).to eq b.map(&:id)
+  end
+
+  it "auto-proposes a daihyosen when a forfeit tie completes on confirmation" do
+    x = members(t1, 1).first
+    y = members(t2, 1).first
+    # Symmetric forfeits: team 1 fields only position 1, team 2 only position 2.
+    # Confirmation resolves both forfeits -> wins 1-1, ippons 2-2 -> level and
+    # complete with NO hikiwake (so nothing resolve_lineup! could later wipe).
+    described_class.new(encounter).assign(t1, [x.id])
+    described_class.new(encounter).assign(t2, [nil, y.id])
+
+    expect(encounter.team_fights.where(daihyosen: true).count).to eq 1
+    daihyosen = encounter.team_fights.find_by(daihyosen: true)
+    expect(daihyosen.kenshi_1_id).to eq x.id # team 1's last filled position (1)
+    expect(daihyosen.kenshi_2_id).to eq y.id # team 2's last filled position (2)
+  end
+end

--- a/spec/services/encounter_lineup_suggestion_spec.rb
+++ b/spec/services/encounter_lineup_suggestion_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EncounterLineupSuggestion do
+  let(:tc) { create(:team_category, team_size: 3) }
+  let(:t1) { create(:team, team_category: tc) }
+  let(:t2) { create(:team, team_category: tc) }
+
+  def members(team, count)
+    create_list(:kenshi, count, cup: tc.cup).each do |k|
+      create(:participation, category: tc, team: team, kenshi: k)
+    end
+  end
+
+  it "suggests the order the team used in its previous encounter" do
+    roster = members(t1, 3)
+    members(t2, 3)
+    order = [roster[2], roster[0], roster[1]]
+
+    previous = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    EncounterLineup.new(previous).assign(t1, order.map(&:id))
+
+    fresh = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    expect(described_class.new(fresh).for_slot(1)).to eq order.map(&:id)
+  end
+
+  it "carries forward a forfeit gap from the previous order" do
+    roster = members(t1, 3)
+    members(t2, 3)
+
+    previous = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    EncounterLineup.new(previous).assign(t1, [roster[0].id, nil, roster[2].id])
+
+    fresh = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    expect(described_class.new(fresh).for_slot(1)).to eq [roster[0].id, nil, roster[2].id]
+  end
+
+  it "matches the team regardless of which side it sat on previously" do
+    roster = members(t2, 3)
+    members(t1, 3)
+
+    # t2 was on side 2 before; suggesting for its side here must still find it.
+    previous = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    EncounterLineup.new(previous).assign(t2, roster.map(&:id))
+
+    fresh = create(:encounter, team_category: tc, team_1: t2, team_2: t1)
+    expect(described_class.new(fresh).for_slot(1)).to eq roster.map(&:id)
+  end
+
+  it "falls back to roster order when the team has no previous encounter" do
+    roster = members(t1, 3)
+    members(t2, 3)
+
+    fresh = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    expect(described_class.new(fresh).for_slot(1)).to eq roster.map(&:id)
+  end
+
+  it "ignores the current encounter's own (set) lineup" do
+    roster = members(t1, 3)
+    members(t2, 3)
+
+    fresh = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    EncounterLineup.new(fresh).assign(t1, [roster[1].id, roster[0].id, roster[2].id])
+
+    # No OTHER encounter exists, so it must fall back to roster order, not echo
+    # the lineup already on this encounter.
+    expect(described_class.new(fresh).for_slot(1)).to eq roster.map(&:id)
+  end
+
+  it "returns nothing for an unresolved bracket slot" do
+    fresh = create(:encounter, team_category: tc, team_1: nil, team_2: nil, round: 2, position: 1)
+    expect(described_class.new(fresh).for_slot(1)).to eq []
+  end
+end

--- a/spec/services/encounter_result_spec.rb
+++ b/spec/services/encounter_result_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EncounterResult do
+  let(:tc) { create(:team_category, team_size: 3) }
+  let(:t1) { create(:team, team_category: tc) }
+  let(:t2) { create(:team, team_category: tc) }
+  let(:encounter) { create(:encounter, team_category: tc, team_1: t1, team_2: t2) }
+
+  # Build a regular fight at the next position; winner_side: 1, 2, or nil (draw).
+  def bout(winner_side, ippons_1: 0, ippons_2: 0, daihyosen: false)
+    a = create(:kenshi, cup: tc.cup)
+    b = create(:kenshi, cup: tc.cup)
+    tf = create(:team_fight, encounter: encounter, kenshi_1: a, kenshi_2: b, daihyosen: daihyosen)
+    ippons_1.times { create(:fight_point, scorable: tf, fighter_side: "fighter_1", kind: "men") }
+    ippons_2.times { create(:fight_point, scorable: tf, fighter_side: "fighter_2", kind: "men") }
+    tf.reload
+  end
+
+  it "wins on the higher number of individual winners" do
+    bout(1, ippons_1: 1)
+    bout(2, ippons_2: 1)
+    bout(1, ippons_1: 1)
+    expect(described_class.new(encounter.reload).winner).to eq t1
+  end
+
+  it "breaks a 1-1 wins tie on total points" do
+    bout(1, ippons_1: 2) # t1: 1 win, 2 ippons
+    bout(2, ippons_2: 1) # t2: 1 win, 1 ippon
+    bout(nil, ippons_1: 1, ippons_2: 1) # draw, +1 ippon each
+    # wins 1-1; ippons 3-2 -> t1
+    expect(described_class.new(encounter.reload).winner).to eq t1
+  end
+
+  it "is unresolved when wins and ippons tie and there is no daihyosen" do
+    bout(1, ippons_1: 1)
+    bout(2, ippons_2: 1)
+    bout(nil)
+    expect(described_class.new(encounter.reload).winner).to be_nil
+  end
+
+  it "resolves a full tie via the daihyosen winner's team once complete" do
+    bout(1, ippons_1: 1)
+    bout(2, ippons_2: 1)
+    bout(nil).update!(draw: true) # hikiwake resolves the third regular bout
+    bout(2, ippons_2: 1, daihyosen: true) # representative of team 2 wins
+    encounter.update!(lineup_1_set: true, lineup_2_set: true)
+    expect(described_class.new(encounter.reload).winner).to eq t2
+  end
+
+  it "ignores a scored daihyosen while a regular bout is still unresolved" do
+    bout(1, ippons_1: 1)
+    bout(2, ippons_2: 1)
+    bout(nil) # left unresolved -> encounter not complete
+    bout(2, ippons_2: 1, daihyosen: true)
+    encounter.update!(lineup_1_set: true, lineup_2_set: true)
+    expect(described_class.new(encounter.reload).winner).to be_nil
+  end
+
+  describe "completeness and draws" do
+    let(:tc) { create(:team_category, team_size: 3) }
+
+    def lineup(slot, *members)
+      members.each_with_index do |m, i|
+        tf = encounter.team_fights.find_or_create_by!(position: i + 1)
+        tf.update!("kenshi_#{slot}_id": m&.id)
+      end
+      encounter.update!("lineup_#{slot}_set": true)
+    end
+
+    it "is not complete until both lineups are in" do
+      a = Array.new(3) { create(:kenshi, cup: tc.cup) }
+      lineup(1, *a)
+      expect(described_class.new(encounter.reload).complete?).to be false
+    end
+
+    it "is not complete while a non-void bout is unresolved" do
+      a = Array.new(3) { create(:kenshi, cup: tc.cup) }
+      b = Array.new(3) { create(:kenshi, cup: tc.cup) }
+      lineup(1, *a)
+      lineup(2, *b)
+      expect(described_class.new(encounter.reload).complete?).to be false # no points scored yet
+    end
+
+    it "treats a finished tied encounter as a draw for both teams" do
+      a = Array.new(3) { create(:kenshi, cup: tc.cup) }
+      b = Array.new(3) { create(:kenshi, cup: tc.cup) }
+      lineup(1, *a)
+      lineup(2, *b)
+      fights = encounter.team_fights.order(:position).to_a
+      create(:fight_point, scorable: fights[0], fighter_side: "fighter_1", kind: "men") # t1 win
+      create(:fight_point, scorable: fights[1], fighter_side: "fighter_2", kind: "men") # t2 win
+      fights[2].update!(draw: true) # hikiwake
+      res = described_class.new(encounter.reload)
+
+      expect(res.complete?).to be true
+      expect(res.outcome_for(t1)).to eq :draw
+      expect(res.outcome_for(t2)).to eq :draw
+      expect(res.hikiwake).to eq 1
+      expect(res.team_1_losses).to eq res.team_2_wins
+    end
+
+    it "is complete with void trailing bouts (two short teams)" do
+      a = Array.new(2) { create(:kenshi, cup: tc.cup) }
+      b = Array.new(2) { create(:kenshi, cup: tc.cup) }
+      lineup(1, a[0], a[1], nil)
+      lineup(2, b[0], b[1], nil)
+      fights = encounter.team_fights.order(:position).to_a
+      create(:fight_point, scorable: fights[0], fighter_side: "fighter_1", kind: "men")
+      fights[1].update!(draw: true) # resolve the second real fight
+      res = described_class.new(encounter.reload)
+
+      expect(res.complete?).to be true # the position-3 void bout doesn't block completeness
+      expect(res.team_1_wins).to eq 1  # void bout excluded from the win count
+      expect(res.team_2_wins).to eq 0
+      expect(res.hikiwake).to eq 1
+      expect(res.outcome_for(t1)).to eq :win
+    end
+  end
+end

--- a/spec/services/encounter_team_swap_spec.rb
+++ b/spec/services/encounter_team_swap_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EncounterTeamSwap do
+  let(:cup) { create(:cup) }
+  let(:category) { create(:team_category, cup: cup, pool_size: nil) }
+
+  def build_bracket(team_count)
+    create_list(:team, team_count, team_category: category)
+    TeamCategoryBracketBuilder.new(category, random: Random.new(1)).call
+  end
+
+  def round_one
+    category.bracket_encounters.where(round: 1).order(:position).to_a
+  end
+
+  describe "#swap" do
+    it "exchanges the occupants of two round-1 slots" do
+      build_bracket(4)
+      first, second = round_one
+      moving_in = second.team_1
+      moving_out = first.team_1
+
+      described_class.new(first).swap(1, moving_in)
+
+      expect(first.reload.team_1).to eq moving_in
+      expect(second.reload.team_1).to eq moving_out
+    end
+
+    it "re-seeds the round-2 slot when a bye occupant is swapped out" do
+      build_bracket(3)
+      bye = round_one.detect(&:bye?)
+      fight = round_one.detect { |e| !e.bye? }
+      final = category.bracket_encounters.find_by(round: 2)
+      moving_in = fight.team_1
+
+      described_class.new(bye).swap(bye.bye_slot, moving_in)
+
+      slot = (final.parent_encounter_1_id == bye.id) ? 1 : 2
+      expect(final.reload.public_send(:"team_#{slot}_id")).to eq moving_in.id
+    end
+
+    it "rejects a team that does not occupy a bracket slot" do
+      build_bracket(4)
+      newcomer = create(:team, team_category: category)
+
+      expect { described_class.new(round_one.first).swap(1, newcomer) }
+        .to raise_error(described_class::InvalidSwap, /exactly one bracket slot/)
+    end
+
+    it "rejects a swap within the same encounter" do
+      build_bracket(4)
+      encounter = round_one.first
+
+      expect { described_class.new(encounter).swap(1, encounter.team_2) }
+        .to raise_error(described_class::InvalidSwap, /already in this encounter/)
+    end
+
+    it "rejects the team already occupying the slot" do
+      build_bracket(4)
+      encounter = round_one.first
+
+      expect { described_class.new(encounter).swap(1, encounter.team_1) }
+        .to raise_error(described_class::InvalidSwap, /already occupies/)
+    end
+
+    it "rejects an empty slot" do
+      build_bracket(3)
+      bye = round_one.detect(&:bye?)
+      empty_slot = (bye.bye_slot == 1) ? 2 : 1
+
+      expect { described_class.new(bye).swap(empty_slot, round_one.detect { |e| !e.bye? }.team_1) }
+        .to raise_error(described_class::InvalidSwap, /no team to swap/)
+    end
+
+    it "rejects when an involved encounter has a winner" do
+      build_bracket(4)
+      first, second = round_one
+      second.update!(winner: second.team_1)
+
+      expect { described_class.new(first).swap(1, second.team_1) }
+        .to raise_error(described_class::InvalidSwap, /recorded results/)
+    end
+
+    it "rejects when an involved encounter has a lineup set" do
+      build_bracket(4)
+      first, second = round_one
+      first.update!(lineup_1_set: true)
+
+      expect { described_class.new(first).swap(1, second.team_1) }
+        .to raise_error(described_class::InvalidSwap, /recorded results/)
+    end
+
+    it "rejects when a bye-fed round-2 child has recorded fight points" do
+      build_bracket(3)
+      bye = round_one.detect(&:bye?)
+      fight = round_one.detect { |e| !e.bye? }
+      final = category.bracket_encounters.find_by(round: 2)
+      team_fight = create(:team_fight, encounter: final)
+      create(:fight_point, scorable: team_fight, fighter_side: "fighter_1")
+
+      expect { described_class.new(bye).swap(bye.bye_slot, fight.team_1) }
+        .to raise_error(described_class::InvalidSwap, /recorded results/)
+    end
+
+    it "rejects a swap on a round-2 encounter" do
+      build_bracket(3)
+      final = category.bracket_encounters.find_by(round: 2)
+      fight = round_one.detect { |e| !e.bye? }
+
+      expect { described_class.new(final).swap(1, fight.team_1) }
+        .to raise_error(described_class::InvalidSwap, /round-1/)
+    end
+
+    it "rejects swaps on pooled categories" do
+      pooled = create(:team_category, cup: cup, pool_size: 3, out_of_pool: 1)
+      create(:team, team_category: pooled, pool_number: 1, pool_rank: 1)
+      create(:team, team_category: pooled, pool_number: 2, pool_rank: 1)
+      TeamCategoryBracketBuilder.new(pooled).call
+      encounter = pooled.bracket_encounters.find_by(round: 1)
+
+      expect { described_class.new(encounter).swap(1, encounter.team_2) }
+        .to raise_error(described_class::InvalidSwap, /bracket-only/)
+    end
+  end
+
+  describe "#swappable? and #candidates" do
+    it "offers occupied pristine round-1 slots and every other occupant" do
+      build_bracket(3)
+      bye = round_one.detect(&:bye?)
+      fight = round_one.detect { |e| !e.bye? }
+      swap = described_class.new(bye)
+
+      expect(swap.swappable?(bye.bye_slot)).to be true
+      expect(swap.swappable?((bye.bye_slot == 1) ? 2 : 1)).to be false
+      expect(swap.candidates(bye.bye_slot)).to contain_exactly(fight.team_1, fight.team_2)
+    end
+
+    it "withdraws the offer once results exist" do
+      build_bracket(4)
+      encounter = round_one.first
+      encounter.update!(lineup_2_set: true)
+
+      expect(described_class.new(encounter).swappable?(1)).to be false
+    end
+  end
+end

--- a/spec/services/pool_encounter_generator_spec.rb
+++ b/spec/services/pool_encounter_generator_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PoolEncounterGenerator do
+  let(:tc) { create(:team_category, pool_size: 3) }
+
+  def pooled_team(number, position)
+    create(:team, team_category: tc, pool_number: number, pool_position: position)
+  end
+
+  it "creates the cyclic round-robin for a pool of 3 (pairs 1-2, 3-2, 3-1)" do
+    t1 = pooled_team(1, 1)
+    t2 = pooled_team(1, 2)
+    t3 = pooled_team(1, 3)
+
+    described_class.new(tc).call
+
+    pairs = tc.encounters.where(pool_number: 1).map { |e| [e.team_1_id, e.team_2_id] }
+    expect(pairs).to eq [[t1.id, t2.id], [t3.id, t2.id], [t3.id, t1.id]]
+  end
+
+  it "creates one encounter for a pool of 2" do
+    a = pooled_team(2, 1)
+    b = pooled_team(2, 2)
+    described_class.new(tc).call
+    expect(tc.encounters.where(pool_number: 2).pluck(:team_1_id, :team_2_id)).to eq [[a.id, b.id]]
+  end
+
+  it "is idempotent — a second call adds no duplicate encounters" do
+    pooled_team(1, 1)
+    pooled_team(1, 2)
+    pooled_team(1, 3)
+    described_class.new(tc).call
+    expect { described_class.new(tc).call }.not_to change { tc.encounters.count }
+  end
+end

--- a/spec/services/pool_membership_move_spec.rb
+++ b/spec/services/pool_membership_move_spec.rb
@@ -1,0 +1,241 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PoolMembershipMove do
+  let(:cup) { create(:cup) }
+  let(:category) { create(:individual_category, cup: cup, pool_size: 3, out_of_pool: 2) }
+
+  def member_in(pool, position, rank: nil)
+    kenshi = create(:kenshi, cup: cup)
+    create(:participation, category: category, kenshi: kenshi,
+      pool_number: pool, pool_position: position, pool_rank: rank)
+  end
+
+  def unpooled_member
+    create(:participation, category: category,
+      kenshi: create(:kenshi, cup: cup), pool_number: nil, pool_position: nil)
+  end
+
+  describe "membership change" do
+    it "appends the moved member to the destination and compacts the source" do
+      a = member_in(1, 1)
+      b = member_in(1, 2)
+      c = member_in(1, 3)
+      member_in(2, 1)
+      member_in(2, 2)
+
+      result = described_class.new(participation: b, to_pool_number: 2).call
+
+      expect(result.status).to eq :ok
+      expect(b.reload.pool_number).to eq 2
+      expect(b.pool_position).to eq 3
+      expect(a.reload.pool_position).to eq 1
+      expect(c.reload.pool_position).to eq 2
+    end
+
+    it "is a no-op when the destination is the current pool" do
+      a = member_in(1, 1)
+      member_in(1, 2)
+
+      result = described_class.new(participation: a, to_pool_number: 1).call
+
+      expect(result.status).to eq :noop
+      expect(a.reload.pool_position).to eq 1
+    end
+
+    it "reports an emptied source pool" do
+      lonely = member_in(1, 1)
+      member_in(2, 1)
+
+      result = described_class.new(participation: lonely, to_pool_number: 2).call
+
+      expect(result.emptied_pools).to eq [1]
+      expect(category.pools.map(&:number)).to eq [2]
+    end
+
+    it "resets pool_rank for members in both affected pools" do
+      a = member_in(1, 1, rank: 1)
+      b = member_in(1, 2, rank: 2)
+      d = member_in(2, 1, rank: 1)
+
+      described_class.new(participation: b, to_pool_number: 2).call
+
+      expect([a, b, d].map { |p| p.reload.pool_rank }).to eq [nil, nil, nil]
+    end
+  end
+
+  describe "pool fights" do
+    it "creates no fights during setup (none existed yet)" do
+      member_in(1, 1)
+      b = member_in(1, 2)
+      member_in(1, 3)
+      member_in(2, 1)
+
+      described_class.new(participation: b, to_pool_number: 2).call
+
+      expect(category.pool_fights.count).to eq 0
+    end
+
+    it "regenerates both pools' cyclic fights to match the new membership" do
+      member_in(1, 1)
+      b = member_in(1, 2)
+      member_in(1, 3)
+      member_in(2, 1)
+      PoolFightGenerator.new(category).call
+
+      expect(category.pool_fights.where(pool_number: 1).count).to eq 3
+
+      described_class.new(participation: b, to_pool_number: 2).call
+
+      expect(category.pool_fights.where(pool_number: 1).count).to eq 1
+      expect(category.pool_fights.where(pool_number: 2).count).to eq 1
+    end
+
+    it "destroys dependent fight_points (no orphans) when wiping fights" do
+      member_in(1, 1)
+      b = member_in(1, 2)
+      member_in(1, 3)
+      member_in(2, 1)
+      PoolFightGenerator.new(category).call
+      fight = category.pool_fights.where(pool_number: 1).first
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
+
+      expect { described_class.new(participation: b, to_pool_number: 2, force: true).call }
+        .to change(FightPoint, :count).by(-1)
+    end
+  end
+
+  describe "confirmation gate" do
+    it "needs confirmation (and writes nothing) when an affected pool has a recorded result" do
+      member_in(1, 1)
+      b = member_in(1, 2)
+      member_in(1, 3)
+      member_in(2, 1)
+      PoolFightGenerator.new(category).call
+      category.pool_fights.where(pool_number: 1).first.update_column(:draw, true)
+
+      result = described_class.new(participation: b, to_pool_number: 2).call
+
+      expect(result.status).to eq :needs_confirmation
+      expect(b.reload.pool_number).to eq 1
+      expect(category.pool_fights.where(pool_number: 1).count).to eq 3
+    end
+
+    it "performs the destructive move when forced" do
+      member_in(1, 1)
+      b = member_in(1, 2)
+      member_in(1, 3)
+      member_in(2, 1)
+      PoolFightGenerator.new(category).call
+      category.pool_fights.where(pool_number: 1).first.update_column(:draw, true)
+
+      result = described_class.new(participation: b, to_pool_number: 2, force: true).call
+
+      expect(result.status).to eq :ok
+      expect(b.reload.pool_number).to eq 2
+    end
+  end
+
+  describe "adding an unpooled member" do
+    it "appends a late registrant to an existing pool" do
+      member_in(1, 1)
+      member_in(1, 2)
+      late = unpooled_member
+
+      result = described_class.new(participation: late, to_pool_number: 1).call
+
+      expect(result.status).to eq :ok
+      expect(result.created_pool).to be false
+      expect(late.reload.pool_number).to eq 1
+      expect(late.pool_position).to eq 3
+    end
+
+    it "creates a new pool from a late registrant" do
+      member_in(1, 1)
+      member_in(1, 2)
+      late = unpooled_member
+
+      result = described_class.new(participation: late, to_pool_number: 2).call
+
+      expect(result.status).to eq :ok
+      expect(result.created_pool).to be true
+      expect(late.reload.pool_number).to eq 2
+      expect(late.pool_position).to eq 1
+      expect(category.pools.map(&:number)).to eq [1, 2]
+    end
+  end
+
+  describe "un-pooling a member" do
+    it "removes a member from its pool when no destination is given" do
+      member_in(1, 1)
+      b = member_in(1, 2)
+      member_in(1, 3)
+
+      result = described_class.new(participation: b, to_pool_number: nil).call
+
+      expect(result.status).to eq :ok
+      expect(b.reload.pool_number).to be_nil
+      expect(b.pool_position).to be_nil
+    end
+
+    it "compacts the source pool after un-pooling" do
+      a = member_in(1, 1)
+      b = member_in(1, 2)
+      c = member_in(1, 3)
+
+      described_class.new(participation: b, to_pool_number: nil).call
+
+      expect(a.reload.pool_position).to eq 1
+      expect(c.reload.pool_position).to eq 2
+    end
+
+    it "clears the moved member's stale pool_rank when un-pooling" do
+      ranked = member_in(1, 1, rank: 1)
+      member_in(1, 2, rank: 2)
+
+      described_class.new(participation: ranked, to_pool_number: nil).call
+
+      expect(ranked.reload.pool_rank).to be_nil
+    end
+
+    it "is a no-op when un-pooling an already-unpooled member" do
+      late = unpooled_member
+
+      result = described_class.new(participation: late, to_pool_number: nil).call
+
+      expect(result.status).to eq :noop
+    end
+  end
+
+  describe "bracket" do
+    it "needs confirmation when a bracket exists" do
+      member_in(1, 1, rank: 1)
+      member_in(1, 2, rank: 2)
+      b = member_in(1, 3, rank: 3)
+      member_in(2, 1, rank: 1)
+      member_in(2, 2, rank: 2)
+      IndividualCategoryBracketBuilder.new(category).call
+      expect(category.bracket_fights).to be_any
+
+      result = described_class.new(participation: b, to_pool_number: 2).call
+
+      expect(result.status).to eq :needs_confirmation
+    end
+
+    it "clears the bracket on a forced move" do
+      member_in(1, 1, rank: 1)
+      member_in(1, 2, rank: 2)
+      b = member_in(1, 3, rank: 3)
+      member_in(2, 1, rank: 1)
+      member_in(2, 2, rank: 2)
+      IndividualCategoryBracketBuilder.new(category).call
+
+      result = described_class.new(participation: b, to_pool_number: 2, force: true).call
+
+      expect(result.status).to eq :ok
+      expect(result.bracket_cleared).to be true
+      expect(category.bracket_fights.reload).to be_empty
+    end
+  end
+end

--- a/spec/services/pool_standings_spec.rb
+++ b/spec/services/pool_standings_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe PoolStandings do
     fight = create(:fight, :pool_fight, individual_category: category, pool_number: 1,
       fighter_1: kenshi_a, fighter_2: kenshi_b,
       tiebreaker: tiebreaker, draw: draw, winner: winner)
-    points_a.times { create(:fight_point, fight: fight, fighter_side: "fighter_1", kind: "men") }
-    points_b.times { create(:fight_point, fight: fight, fighter_side: "fighter_2", kind: "men") }
+    points_a.times { create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men") }
+    points_b.times { create(:fight_point, scorable: fight, fighter_side: "fighter_2", kind: "men") }
     fight
   end
 

--- a/spec/services/team_pool_move_spec.rb
+++ b/spec/services/team_pool_move_spec.rb
@@ -1,0 +1,315 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeamPoolMove do
+  let(:cup) { create(:cup) }
+  let(:tc) { create(:team_category, cup: cup, pool_size: 3, out_of_pool: 2, team_size: 3) }
+
+  def team_in(pool, position, rank: nil)
+    create(:team, team_category: tc, pool_number: pool, pool_position: position, pool_rank: rank)
+  end
+
+  describe "membership change" do
+    it "appends the moved team to the destination and compacts the source" do
+      a = team_in(1, 1)
+      b = team_in(1, 2)
+      c = team_in(1, 3)
+      team_in(2, 1)
+      team_in(2, 2)
+
+      result = described_class.new(team: b, to_pool_number: 2).call
+
+      expect(result.status).to eq :ok
+      expect(b.reload.pool_number).to eq 2
+      expect(b.pool_position).to eq 3 # appended after the two destination teams
+      expect(a.reload.pool_position).to eq 1
+      expect(c.reload.pool_position).to eq 2 # gap closed
+    end
+
+    it "is a no-op when the destination is the current pool" do
+      a = team_in(1, 1)
+      team_in(1, 2)
+
+      result = described_class.new(team: a, to_pool_number: 1).call
+
+      expect(result.status).to eq :noop
+      expect(a.reload.pool_position).to eq 1
+    end
+
+    it "reports an emptied source pool" do
+      lonely = team_in(1, 1)
+      team_in(2, 1)
+
+      result = described_class.new(team: lonely, to_pool_number: 2).call
+
+      expect(result.emptied_pools).to eq [1]
+      expect(tc.team_pools.map(&:number)).to eq [2]
+    end
+
+    it "resets pool_rank for teams in both affected pools" do
+      a = team_in(1, 1, rank: 1)
+      b = team_in(1, 2, rank: 2)
+      d = team_in(2, 1, rank: 1)
+
+      described_class.new(team: b, to_pool_number: 2).call
+
+      expect([a, b, d].map { |t| t.reload.pool_rank }).to eq [nil, nil, nil]
+    end
+  end
+
+  describe "pool encounters" do
+    it "creates no encounters during setup (none existed yet)" do
+      team_in(1, 1)
+      b = team_in(1, 2)
+      team_in(1, 3)
+      team_in(2, 1)
+
+      described_class.new(team: b, to_pool_number: 2).call
+
+      expect(tc.encounters.count).to eq 0
+    end
+
+    it "regenerates both pools' round-robins to match the new membership" do
+      team_in(1, 1)
+      b = team_in(1, 2)
+      team_in(1, 3)
+      team_in(2, 1)
+      PoolEncounterGenerator.new(tc).call # pool 1: C(3) -> 3 encounters, pool 2: 1 team -> 0
+
+      expect(tc.encounters.where(pool_number: 1).count).to eq 3
+
+      described_class.new(team: b, to_pool_number: 2).call
+
+      # pool 1 now has 2 teams (1 encounter), pool 2 has 2 teams (1 encounter)
+      expect(tc.encounters.where(pool_number: 1).count).to eq 1
+      expect(tc.encounters.where(pool_number: 2).count).to eq 1
+      expect(tc.encounters.where.not(pool_number: [1, 2]).count).to eq 0
+    end
+
+    it "destroys dependent team_fights and fight_points (no orphans) when wiping encounters" do
+      team_in(1, 1)
+      b = team_in(1, 2)
+      team_in(1, 3)
+      team_in(2, 1)
+      PoolEncounterGenerator.new(tc).call
+      enc = tc.encounters.where(pool_number: 1).first
+      fight = create(:team_fight, encounter: enc)
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
+
+      expect { described_class.new(team: b, to_pool_number: 2, force: true).call }
+        .to change(TeamFight, :count).by(-1)
+        .and change(FightPoint, :count).by(-1)
+    end
+  end
+
+  describe "confirmation gate" do
+    it "needs confirmation (and writes nothing) when an affected pool has a set lineup" do
+      team_in(1, 1)
+      b = team_in(1, 2)
+      team_in(1, 3)
+      team_in(2, 1)
+      PoolEncounterGenerator.new(tc).call
+      tc.encounters.where(pool_number: 1).first.update!(lineup_1_set: true)
+
+      result = described_class.new(team: b, to_pool_number: 2).call
+
+      expect(result.status).to eq :needs_confirmation
+      expect(b.reload.pool_number).to eq 1 # unchanged
+      expect(tc.encounters.where(pool_number: 1).count).to eq 3 # unchanged
+    end
+
+    it "needs confirmation when an affected pool has recorded fight points" do
+      team_in(1, 1)
+      b = team_in(1, 2)
+      team_in(1, 3)
+      team_in(2, 1)
+      PoolEncounterGenerator.new(tc).call
+      enc = tc.encounters.where(pool_number: 1).first
+      fight = create(:team_fight, encounter: enc)
+      create(:fight_point, scorable: fight, fighter_side: "fighter_1", kind: "men")
+
+      result = described_class.new(team: b, to_pool_number: 2).call
+
+      expect(result.status).to eq :needs_confirmation
+    end
+
+    it "performs the destructive move when forced" do
+      team_in(1, 1)
+      b = team_in(1, 2)
+      team_in(1, 3)
+      team_in(2, 1)
+      PoolEncounterGenerator.new(tc).call
+      tc.encounters.where(pool_number: 1).first.update!(lineup_1_set: true)
+
+      result = described_class.new(team: b, to_pool_number: 2, force: true).call
+
+      expect(result.status).to eq :ok
+      expect(b.reload.pool_number).to eq 2
+    end
+  end
+
+  describe "adding an unpooled team" do
+    def unpooled_team
+      create(:team, team_category: tc, pool_number: nil, pool_position: nil)
+    end
+
+    it "appends a late registrant to an existing pool" do
+      team_in(1, 1)
+      team_in(1, 2)
+      late = unpooled_team
+
+      result = described_class.new(team: late, to_pool_number: 1).call
+
+      expect(result.status).to eq :ok
+      expect(result.created_pool).to be false
+      expect(late.reload.pool_number).to eq 1
+      expect(late.pool_position).to eq 3
+    end
+
+    it "creates a new pool from a late registrant" do
+      team_in(1, 1)
+      team_in(1, 2)
+      late = unpooled_team
+
+      result = described_class.new(team: late, to_pool_number: 2).call
+
+      expect(result.status).to eq :ok
+      expect(result.created_pool).to be true
+      expect(late.reload.pool_number).to eq 2
+      expect(late.pool_position).to eq 1
+      expect(tc.team_pools.map(&:number)).to eq [1, 2]
+    end
+
+    it "regenerates the destination pool's round-robin when encounters exist" do
+      team_in(1, 1)
+      team_in(1, 2)
+      PoolEncounterGenerator.new(tc).call
+      expect(tc.encounters.where(pool_number: 1).count).to eq 1
+      late = unpooled_team
+
+      described_class.new(team: late, to_pool_number: 1).call
+
+      expect(tc.encounters.where(pool_number: 1).count).to eq 3 # round-robin of 3
+    end
+
+    it "leaves bracket/ad-hoc (pool_number nil) encounters untouched" do
+      team_in(1, 1, rank: 1)
+      team_in(2, 1, rank: 1)
+      late = unpooled_team
+      TeamCategoryBracketBuilder.new(tc).call
+      bracket_count = tc.bracket_encounters.count
+
+      described_class.new(team: late, to_pool_number: 2, force: true).call
+
+      # the bracket is cleared deliberately, but never via the pool-wipe of a nil source
+      expect(bracket_count).to be_positive
+    end
+
+    it "needs confirmation when the destination pool is non-pristine" do
+      team_in(1, 1)
+      team_in(1, 2)
+      PoolEncounterGenerator.new(tc).call
+      tc.encounters.where(pool_number: 1).first.update!(lineup_1_set: true)
+      late = unpooled_team
+
+      result = described_class.new(team: late, to_pool_number: 1).call
+
+      expect(result.status).to eq :needs_confirmation
+      expect(late.reload.pool_number).to be_nil
+    end
+  end
+
+  describe "un-pooling a team" do
+    it "removes a team from its pool when no destination is given" do
+      team_in(1, 1)
+      b = team_in(1, 2)
+      team_in(1, 3)
+
+      result = described_class.new(team: b, to_pool_number: nil).call
+
+      expect(result.status).to eq :ok
+      expect(result.created_pool).to be false
+      expect(b.reload.pool_number).to be_nil
+      expect(b.pool_position).to be_nil
+    end
+
+    it "compacts the source pool after un-pooling" do
+      a = team_in(1, 1)
+      b = team_in(1, 2)
+      c = team_in(1, 3)
+
+      described_class.new(team: b, to_pool_number: nil).call
+
+      expect(a.reload.pool_position).to eq 1
+      expect(c.reload.pool_position).to eq 2
+    end
+
+    it "reports the source emptied when un-pooling its last team" do
+      only = team_in(1, 1)
+
+      result = described_class.new(team: only, to_pool_number: "").call
+
+      expect(result.emptied_pools).to eq [1]
+      expect(tc.team_pools).to be_empty
+    end
+
+    it "regenerates the source pool's round-robin after un-pooling" do
+      team_in(1, 1)
+      b = team_in(1, 2)
+      team_in(1, 3)
+      PoolEncounterGenerator.new(tc).call
+      expect(tc.encounters.where(pool_number: 1).count).to eq 3
+
+      described_class.new(team: b, to_pool_number: nil).call
+
+      expect(tc.encounters.where(pool_number: 1).count).to eq 1 # 2 teams remain
+    end
+
+    it "clears the moved team's stale pool_rank when un-pooling" do
+      ranked = team_in(1, 1, rank: 1)
+      team_in(1, 2, rank: 2)
+
+      described_class.new(team: ranked, to_pool_number: nil).call
+
+      expect(ranked.reload.pool_rank).to be_nil
+    end
+
+    it "is a no-op when un-pooling an already-unpooled team" do
+      late = create(:team, team_category: tc, pool_number: nil)
+
+      result = described_class.new(team: late, to_pool_number: nil).call
+
+      expect(result.status).to eq :noop
+    end
+  end
+
+  describe "bracket" do
+    it "needs confirmation when a bracket exists" do
+      team_in(1, 1, rank: 1)
+      b = team_in(1, 2, rank: 2)
+      team_in(2, 1, rank: 1)
+      team_in(2, 2, rank: 2)
+      TeamCategoryBracketBuilder.new(tc).call
+      expect(tc.bracket_encounters).to be_any
+
+      result = described_class.new(team: b, to_pool_number: 2).call
+
+      expect(result.status).to eq :needs_confirmation
+    end
+
+    it "clears the bracket on a forced move" do
+      team_in(1, 1, rank: 1)
+      b = team_in(1, 2, rank: 2)
+      team_in(2, 1, rank: 1)
+      team_in(2, 2, rank: 2)
+      TeamCategoryBracketBuilder.new(tc).call
+
+      result = described_class.new(team: b, to_pool_number: 2, force: true).call
+
+      expect(result.status).to eq :ok
+      expect(result.bracket_cleared).to be true
+      expect(tc.bracket_encounters.reload).to be_empty
+    end
+  end
+end

--- a/spec/services/team_pool_standings_spec.rb
+++ b/spec/services/team_pool_standings_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeamPoolStandings do
+  let(:tc) { create(:team_category, team_size: 3, pool_size: 3) }
+  let(:teams) { Array.new(3) { |i| create(:team, team_category: tc, pool_number: 1, pool_position: i + 1) } }
+
+  # Build a COMPLETE pool encounter between teams[a] and teams[b] with the given
+  # per-position bout winners (1 = team_a kenshi, 2 = team_b kenshi, :draw). Builds
+  # the team_fights directly (no EncounterLineup) so we needn't register each
+  # kenshi as a team member just to exercise the standings.
+  def encounter_between(a, b, results)
+    enc = create(:encounter, team_category: tc, pool_number: 1, team_1: teams[a], team_2: teams[b])
+    fights = results.each_index.map do |i|
+      enc.team_fights.create!(position: i + 1,
+        kenshi_1: create(:kenshi, cup: tc.cup), kenshi_2: create(:kenshi, cup: tc.cup))
+    end
+    enc.update!(lineup_1_set: true, lineup_2_set: true)
+    results.each_with_index do |result, i|
+      case result
+      when 1 then create(:fight_point, scorable: fights[i], fighter_side: "fighter_1", kind: "men")
+      when 2 then create(:fight_point, scorable: fights[i], fighter_side: "fighter_2", kind: "men")
+      when :draw then fights[i].update!(draw: true)
+      end
+    end
+    enc
+  end
+
+  it "ranks by team wins, then the cascade, and persists pool_rank" do
+    teams # instantiate
+    e1 = encounter_between(0, 1, [1, 1, 2]) # team0 beats team1 (2-1 bouts)
+    e2 = encounter_between(0, 2, [1, 1, 1]) # team0 beats team2 (3-0)
+    e3 = encounter_between(1, 2, [1, 1, 2]) # team1 beats team2 (2-1)
+    encounters = [e1, e2, e3]
+
+    rows = described_class.for(teams: teams, encounters: encounters)
+    expect(rows.map { |r| r.team.id }).to eq [teams[0].id, teams[1].id, teams[2].id]
+    expect(rows.first.team_wins).to eq 2
+
+    described_class.persist_ranks!(teams: teams, encounters: encounters)
+    expect(teams[0].reload.pool_rank).to eq 1
+    expect(teams[1].reload.pool_rank).to eq 2
+    expect(teams[2].reload.pool_rank).to eq 3
+  end
+
+  it "counts a drawn encounter as a draw for both teams" do
+    teams
+    enc = encounter_between(0, 1, [1, 2, :draw]) # 1 win each, ippons equal -> encounter draw
+    rows = described_class.for(teams: teams, encounters: [enc])
+    by_team = rows.index_by { |r| r.team.id }
+    expect(by_team[teams[0].id].team_hikiwake).to eq 1
+    expect(by_team[teams[1].id].team_hikiwake).to eq 1
+  end
+
+  it "flags an unbroken full tie and still assigns distinct ranks" do
+    teams
+    e1 = encounter_between(0, 2, [1, 1, 1]) # team0 beats team2
+    e2 = encounter_between(1, 2, [1, 1, 1]) # team1 beats team2 (identically)
+    rows = described_class.for(teams: teams, encounters: [e1, e2])
+    top_two = rows.first(2)
+    expect(top_two.map(&:tied)).to eq [true, true]
+    expect(rows.last.tied).to be false # unambiguous last place is not flagged tied
+    expect(rows.map(&:rank)).to eq [1, 2, 3] # distinct ranks despite the tie
+  end
+
+  it "returns unranked rows when no encounter is complete" do
+    teams
+    enc = create(:encounter, team_category: tc, pool_number: 1, team_1: teams[0], team_2: teams[1])
+    enc.team_fights.create!(position: 1, kenshi_1: create(:kenshi, cup: tc.cup),
+      kenshi_2: create(:kenshi, cup: tc.cup)) # no lineup flags set -> not complete
+
+    rows = described_class.for(teams: teams, encounters: [enc])
+
+    expect(rows.map(&:rank)).to all(be_nil)
+    described_class.persist_ranks!(teams: teams, encounters: [enc])
+    expect(teams.map { |t| t.reload.pool_rank }).to all(be_nil)
+  end
+end

--- a/spec/system/admin_bracket_panel_spec.rb
+++ b/spec/system/admin_bracket_panel_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Admin bracket encounter panel", :js do
+  let(:cup) { create(:cup) }
+  let(:category) { create(:team_category, cup: cup, pool_size: nil) }
+  let(:admin) { create(:user, :admin) }
+
+  before do
+    create_list(:team, 4, team_category: category)
+    TeamCategoryBracketBuilder.new(category, random: Random.new(1)).call
+  end
+
+  def panel_selector
+    "turbo-frame#encounter_panel_team_category_#{category.id}"
+  end
+
+  it "opens the editor below the tree, closes it, and reopens another encounter" do
+    signin_and_visit(admin, admin_team_category_path(category))
+
+    click_link "Encounter 1"
+
+    within(panel_selector) { expect(page).to have_button("Close") }
+    # The bracket tree is still on the page, above the editor.
+    expect(page).to have_css(".competition-tree")
+
+    click_button "Close"
+    expect(page).to have_no_button("Close")
+    expect(page).to have_css(".competition-tree")
+
+    # Re-clicking the SAME encounter must reload the panel — this is what the
+    # controller's src-clearing guards against (a surviving src would make
+    # Turbo treat the navigation as a no-op and leave the panel empty).
+    click_link "Encounter 1"
+    within(panel_selector) { expect(page).to have_button("Close") }
+
+    # Clicking another card swaps its editor into the same (already open)
+    # panel — assert encounter-2 content, since the Close button alone would
+    # still be there from the encounter-1 editor.
+    second = category.bracket_encounters.where(round: 1).order(:position).second
+    click_link "Encounter 2"
+    within(panel_selector) { expect(page).to have_text(second.team_1.name) }
+  end
+end

--- a/spec/system/admin_daihyosen_spec.rb
+++ b/spec/system/admin_daihyosen_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Admin daihyosen on a tied bracket encounter", :js do
+  include ActionView::RecordIdentifier
+
+  let(:cup) { create(:cup) }
+  let(:tc) { create(:team_category, cup: cup, team_size: 3) }
+  let(:t1) { create(:team, team_category: tc) }
+  let(:t2) { create(:team, team_category: tc) }
+  let(:admin) { create(:user, :admin) }
+
+  def stock(team, count)
+    create_list(:kenshi, count, cup: cup).each do |k|
+      create(:participation, category: tc, team: team, kenshi: k)
+    end
+  end
+
+  # Mark every regular bout hikiwake. Drive each bout by its own row so a click
+  # never races the panel morph from the previous one: every click replaces the
+  # whole #encounter panel, so we click within a bout's stable row, then wait
+  # for *that* bout's button to flip to "Hikiwake ✓" before moving on. (Matching
+  # a bare "Hikiwake" + :first against the morphing panel is racy — the click
+  # can land mid-morph or on a stale node.)
+  def mark_all_hikiwake(encounter)
+    encounter.team_fights.where(daihyosen: false).order(:position).each do |fight|
+      within("##{dom_id(encounter)}_position_#{fight.position}") do
+        click_button "Hikiwake", exact: true
+        expect(page).to have_button("Hikiwake ✓", exact: true)
+      end
+    end
+  end
+
+  it "marks every bout hikiwake, auto-proposes the daihyosen, and decides it" do
+    a = stock(t1, 3)
+    b = stock(t2, 3)
+    encounter = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    EncounterLineup.new(encounter).assign(t1, a.map(&:id))
+    EncounterLineup.new(encounter).assign(t2, b.map(&:id))
+
+    signin_and_visit(admin, admin_team_category_encounter_path(tc, encounter))
+
+    mark_all_hikiwake(encounter)
+
+    # The daihyosen bout is auto-created with each team's taisho. The header
+    # text is uppercased by CSS (DAIHYŌSEN), so match case-insensitively.
+    expect(page).to have_content(/daihyōsen/i)
+    within("##{dom_id(encounter)}") do
+      expect(page).to have_select("kenshi_1_id", selected: a.last.full_name)
+      expect(page).to have_select("kenshi_2_id", selected: b.last.full_name)
+    end
+
+    # Score the daihyosen for team 1 -> encounter is decided.
+    daihyosen = encounter.team_fights.find_by(daihyosen: true)
+    within("##{dom_id(daihyosen)}") { click_button "M", match: :first }
+
+    expect(page).to have_text(a.last.full_name) # winner shown
+    expect(encounter.reload.winner).to eq t1
+  end
+end

--- a/spec/system/admin_lineup_autoseed_spec.rb
+++ b/spec/system/admin_lineup_autoseed_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Admin bracket lineup auto-seed", :js do
+  let(:cup) { create(:cup) }
+  let(:category) { create(:team_category, cup: cup, pool_size: nil, team_size: 3) }
+  let(:admin) { create(:user, :admin) }
+
+  def stock(team, count)
+    create_list(:kenshi, count, cup: cup).each do |k|
+      create(:participation, category: category, team: team, kenshi: k)
+    end
+  end
+
+  it "fills a fresh encounter's lineup on open so the fighters are draggable" do
+    create_list(:team, 2, team_category: category).each { |team| stock(team, 3) }
+    TeamCategoryBracketBuilder.new(category, random: Random.new(1)).call
+
+    signin_and_visit(admin, admin_team_category_path(category))
+    click_link "Encounter 1"
+
+    panel = "turbo-frame#encounter_panel_team_category_#{category.id}"
+    within(panel) do
+      # The seed POST on open populated both sides; each filled card now carries
+      # a drag handle, which only renders for a real (persisted) fighter.
+      expect(page).to have_css(".pool-match__grip", minimum: 2)
+    end
+
+    # Seeding confirms the lineup (so the encounter is immediately usable), but
+    # there's no premature tie: completion still needs fought bouts.
+    encounter = category.bracket_encounters.where(round: 1).order(:position).first
+    expect(encounter.team_fights.where.not(kenshi_1_id: nil)).to be_present
+    expect(encounter.reload.lineup_1_set?).to be true
+    expect(encounter.lineup_2_set?).to be true
+    within(panel) { expect(page).to have_no_text("Tied") }
+  end
+end

--- a/spec/system/admin_lineup_reorder_spec.rb
+++ b/spec/system/admin_lineup_reorder_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Admin team lineup drag-to-reorder", :js do
+  let(:cup) { create(:cup) }
+  let(:tc) { create(:team_category, cup: cup, team_size: 3) }
+  let(:t1) { create(:team, team_category: tc) }
+  let(:t2) { create(:team, team_category: tc) }
+  let(:admin) { create(:user, :admin) }
+
+  def member(team, name)
+    create(:kenshi, cup: cup, first_name: name, last_name: "X").tap do |k|
+      create(:participation, category: tc, team: team, kenshi: k)
+    end
+  end
+
+  def position_kenshi_ids(encounter)
+    encounter.team_fights.order(:position).pluck(:kenshi_1_id)
+  end
+
+  it "swaps two fighters in a team column by dragging one onto the other" do
+    encounter = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    a = member(t1, "Aaa")
+    b = member(t1, "Bbb")
+    c = member(t1, "Ccc")
+    member(t2, "Opp")
+
+    EncounterLineup.new(encounter).assign(t1, [a.id, b.id, c.id])
+    signin_and_visit(admin, admin_team_category_encounter_path(tc, encounter))
+
+    col = ".pool-match__side--fighter_1"
+    pos1_grip = find("#encounter_#{encounter.id}_position_1 #{col} .pool-match__grip")
+    pos3_row = find("#encounter_#{encounter.id}_position_3 #{col} .pool-match__row")
+
+    # Drag position 1 onto position 3 — a swap, so only those two exchange.
+    pos1_grip.drag_to(pos3_row, html5: true)
+
+    # Wait for the auto-submit + Turbo morph to land the new order.
+    within("#encounter_#{encounter.id}_position_1 #{col}") do
+      expect(page).to have_select("kenshi_ids[]", selected: c.full_name)
+    end
+
+    expect(position_kenshi_ids(encounter.reload)).to eq [c.id, b.id, a.id]
+  end
+
+  it "does not swap across teams (each column reorders independently)" do
+    encounter = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    a = member(t1, "Aaa")
+    member(t1, "Bbb")
+    member(t1, "Ccc")
+    opp = member(t2, "Opp")
+
+    EncounterLineup.new(encounter).assign(t1, [a.id])
+    EncounterLineup.new(encounter).assign(t2, [opp.id])
+    signin_and_visit(admin, admin_team_category_encounter_path(tc, encounter))
+
+    t1_grip = find("#encounter_#{encounter.id}_position_1 .pool-match__side--fighter_1 .pool-match__grip")
+    t2_row = find("#encounter_#{encounter.id}_position_1 .pool-match__side--fighter_2 .pool-match__row")
+
+    t1_grip.drag_to(t2_row, html5: true)
+
+    # The cross-team drop is rejected client-side, so nothing changed.
+    expect(position_kenshi_ids(encounter.reload).first).to eq a.id
+    expect(encounter.team_fights.order(:position).first.kenshi_2_id).to eq opp.id
+  end
+end

--- a/spec/system/admin_lineup_spec.rb
+++ b/spec/system/admin_lineup_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Admin team lineup via in-table dropdowns", :js do
+  let(:cup) { create(:cup) }
+  let(:tc) { create(:team_category, cup: cup, team_size: 3) }
+  let(:t1) { create(:team, team_category: tc) }
+  let(:t2) { create(:team, team_category: tc) }
+  let(:admin) { create(:user, :admin) }
+
+  def member(team)
+    create(:kenshi, cup: cup).tap { |k| create(:participation, category: tc, team: team, kenshi: k) }
+  end
+
+  it "assigns a fighter straight from the match table and keeps the pick" do
+    encounter = create(:encounter, team_category: tc, team_1: t1, team_2: t2)
+    fighter = member(t1)
+    member(t2)
+
+    signin_and_visit(admin, admin_team_category_encounter_path(tc, encounter))
+
+    side = "#encounter_#{encounter.id}_position_1 .pool-match__side--fighter_1"
+    within(side) { select fighter.full_name, from: "kenshi_ids[]" }
+
+    # No button: the change auto-submits. After the Turbo morph the side now
+    # offers scoring (proving the bout was created) and still shows the pick
+    # (proving the morph didn't blank the select).
+    within(side) do
+      expect(page).to have_button("M")
+      expect(page).to have_select("kenshi_ids[]", selected: fighter.full_name)
+    end
+    expect(encounter.team_fights.find_by(position: 1)&.kenshi_1_id).to eq(fighter.id)
+  end
+
+  it "keeps scroll position on the admin pool page when a fighter is picked" do
+    tc.update!(pool_size: 2)
+    t1.update!(pool_number: 1)
+    t2.update!(pool_number: 1)
+    encounter = create(:encounter, team_category: tc, team_1: t1, team_2: t2, pool_number: 1)
+    fighter = member(t1)
+    member(t2)
+
+    signin_and_visit(admin, admin_team_category_path(tc))
+    page.driver.browser.manage.window.resize_to(1024, 500)
+
+    find("summary", text: t1.name).click
+    side = "#encounter_#{encounter.id}_position_1 .pool-match__side--fighter_1"
+    scroll_to(find("#{side} select"))
+    scrolled = page.evaluate_script("window.scrollY").to_i
+    expect(scrolled).to be > 0 # the dropdown sits below the fold
+
+    within(side) { select fighter.full_name, from: "kenshi_ids[]" }
+    within(side) { expect(page).to have_button("M") } # wait for the update
+
+    # A native submit would 302 to the standalone page and reset scroll to 0.
+    expect(page).to have_current_path(admin_team_category_path(tc))
+    expect(page.evaluate_script("window.scrollY").to_i).to be_within(60).of(scrolled)
+  end
+end


### PR DESCRIPTION
## Summary

Implements **team-category scoring through to the seeded elimination bracket** (Layers A–B.2 of #1176). A team `Encounter` (team-vs-team match) holds positional `TeamFight` bouts; the encounter winner is auto-derived following the official rules: most individual wins → most ippons → daihyōsen play-off. Teams progress pool → bracket, with live inline editing for admins.

What's in this PR:

- **`team_size` (3 or 5)** on `TeamCategory`.
- **`FightPoint` made polymorphic** (`belongs_to :scorable`) and the point-scoring slice of `Fight` extracted into a shared **`Scorable` concern** — **behavior-neutral for individual categories** (existing fight/pool/bracket specs unchanged and green).
- **`Encounter` + `TeamFight`** models, **`EncounterResult`** (wins → ippons → daihyōsen rollup), **`EncounterLineup`** (each team's ordered members → bouts; short lineups become trailing forfeits crediting the opponent 2 points; scored bouts are locked against re-entry).
- Bout rules: sanbon-shobu (win at 2 points), hikiwake on 0-0/1-1, daihyōsen is ippon-shobu.
- **Team pools:** `team_size`-aware pooling, pool encounter generation (single-cycle pairing via `Pools::CyclicPairing`, same as the individual side), `TeamPoolStandings` (official 8-level cascade), and drag-and-drop pool membership moves (`TeamPoolMove`) that rebuild derived pool encounters / bracket.
- **Seeded elimination bracket:** `TeamCategoryBracketBuilder` + `BracketSeeder` / `BracketOnlySeeder` (pooled and bracket-only categories, byes for non-power-of-2 fields), with forward-propagation of resolved teams into child slots.
- **Public results + PDF:** team category bracket PDF (`TeamCategoryBracketPdf`) and match-sheet PDF.
- **Admin UI:** `EncounterComponent` + views with live Turbo broadcast; `Admin::EncountersController` and dedicated sub-resource controllers (lineups, lineup seeds, team swaps, daihyōsens) and `Admin::TeamFightPointsController` (record / remove points); pool and bracket panels on the team-category admin page with drag-and-drop and live standings.

Built via spec → plan → task-by-task TDD, each task spec- and code-reviewed, with a final whole-feature review.

Part of #1176.

### Notable migrations
- `fight_points`: drops the single-table FK, renames `fight_id` → `scorable_id`, adds `scorable_type` (backfilled `Fight`), polymorphic indexes.
- New `encounters` and `team_fights` tables; `team_size` on `team_categories`; pool/bracket columns on `encounters` and `teams`.

## Test Plan
- [x] Full suite green.
- [x] Individual-category regression slice (fight / fight_point / pool_standings / admin fight & pool requests) green — confirms the polymorphic + concern refactor changed no individual behavior.
- [x] New coverage: `TeamFight` outcomes (sanbon/hikiwake/forfeit/daihyōsen), `EncounterResult` precedence, `EncounterLineup` (pairing, forfeit timing, re-entry lock, validations), `TeamPoolStandings`, `TeamCategoryBracketBuilder` (seeding, byes, idempotency, force rebuild), `EncounterComponent` rendering, and `admin/encounters` requests (create/lineup/score/daihyōsen/destroy, invalid-enum → 422, non-admin → redirect).
- [ ] Manual admin smoke: create an encounter, set both lineups, score bouts, confirm the live panel updates and the derived winner/daihyōsen prompt behave; drag a team between pools and confirm the destructive-move confirm/rebuild flow.

> Note: one transient (non-reproducible) failure was observed in a small fraction of full-suite runs, outside this feature's deterministically-green specs — likely a pre-existing flaky system test; flagging in case it surfaces in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
